### PR TITLE
Avoid breaking iterator

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -124,6 +124,7 @@ var loki = (function () {
     for (i; i < len; i += 1) {
       if (this.collections[i].name === name) {
         this.collections.splice(i, 1);
+        break;
       }
     }
   };


### PR DESCRIPTION
Since len is calculated ahead of time, this was causing array bounds violation in iterator.  Assuming only one collection by that name... if found, splice and your done.
