### PR TITLE
maxId undefined when Inflating empty collection

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -165,7 +165,7 @@ var loki = (function () {
         copyColl.data[j] = coll.data[j];
       }
 
-      copyColl.maxId = coll.data.maxId;
+      copyColl.maxId = (coll.data.length == 0)?0:coll.data.maxId;
       copyColl.indices = coll.indices;
       copyColl.idIndex = coll.indices.id;
       copyColl.transactional = coll.transactional;


### PR DESCRIPTION
Probably a rare use case, but I have encountered it.  When inflating a serialized db using loadJSON(), if a collection is empty it will attempt to copy data.maxId to store at collection level, but this is undefined. 
I am simply doing a test for 0 data length and setting to 0 if it is (empty).  Feel free to implement differently if you want.  Thanks for the library!
