### PR TITLE
use istanbul to get code coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 demos/desktop_app/bower_copmonents/
 demos/desktop_app/log
 demos/desktop_app/demo.json
+coverage/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "example": "examples"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/istanbul cover ./tests"
   },
   "repository": {
     "type": "git",
@@ -38,6 +38,7 @@
   "devDependencies": {
     "gulp-uglify": "^0.3.1",
     "gulp": "^3.8.6",
-    "gulp-concat": "^2.3.4"
+    "gulp-concat": "^2.3.4",
+    "istanbul": "^0.3.2"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,2 @@
+require('./test');
+require('./testTyped');


### PR DESCRIPTION
Using 'mocha' and 'istanbul' is more reliable to organize test code.
And will you want to use 'boswerify' to split src to more than one file?
It is easier to read.
