### PR TITLE
Returns empty array on empty collection

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -404,6 +404,10 @@
      * @returns {Resultset} this resultset for further chain ops.
      */
     Resultset.prototype.find = function(query, firstOnly) {
+      if (this.collection.data.length === 0) {
+        return []
+      }
+
       // comparison operators
       function $eq(a, b) {
         return a === b;


### PR DESCRIPTION
If the collection is empty there's no sense in continuing, this adds a short circuit to return an empty array if there are no items in the collection.

Fixes broken test from #32 
