### PR TITLE
Adds better method for detecting env

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -97,7 +97,7 @@
       };
 
       var getENV = function() {
-        if (fs) {
+        if (typeof process !== 'undefined' && process.argv && process.argv[0] === 'node') {
           return 'NODEJS';
         }
 


### PR DESCRIPTION
When bundling loki with browserify an empty dummy stub for `fs` will be included, so we can't rely on `require('fs')` to know which environment we're running in. A better approach would be to check `process.argv[0]` which, I believe, always returns `'node'` for programs running in a node env.

This is important because if automatic persistence is added in the future `readFile` and `writeFile` won't fatal.

An alternative to this approach would be to check for `BROWSER` and `CORDOVA` first and then default to node.
