### PR TITLE
Refactoring of built-in persistence adaptors

### DIFF
--- a/src/lokiCryptedFileAdapter.js
+++ b/src/lokiCryptedFileAdapter.js
@@ -121,8 +121,8 @@ function decrypt(input, secret) {
 
   var salt = new Buffer(input.salt, 'base64'),
     iv = new Buffer(input.iv, 'base64'),
-    keyLength = input.keyLength;
-  iterations = input.iterations;
+    keyLength = input.keyLength,
+   iterations = input.iterations;
 
   try {
 
@@ -137,7 +137,7 @@ function decrypt(input, secret) {
   } catch (err) {
     throw new Error('Unable to decrypt value due to: ' + err);
   }
-};
+}
 
 /**
  * constructor
@@ -145,6 +145,11 @@ function decrypt(input, secret) {
  */
 function lokiCryptedFileAdapter() {};
 
+/**
+ * setSecret() - set the secret to be used during encryption and decryption
+ *
+ * @param {string} secret - the secret to be used
+ */
 lokiCryptedFileAdapter.prototype.setSecret = function setSecret(secret) {
   this.secret = secret;
 };
@@ -169,7 +174,7 @@ lokiCryptedFileAdapter.prototype.loadDatabase = function loadDatabase(dbname, ca
       console.log(decrypted);
     }
   });
-}
+};
 
 /**
  * saveDatabase() - Saves a serialized db to the catalog.
@@ -186,7 +191,7 @@ lokiCryptedFileAdapter.prototype.saveDatabase = function saveDatabase(dbname, db
   if (typeof (callback) === 'function') {
     callback();
   }
-}
+};
 
 module.exports = new lokiCryptedFileAdapter;
 exports.lokiCryptedFileAdapter = lokiCryptedFileAdapter;

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -764,7 +764,6 @@
      * @param {function} callback - the callback to handle the result
      */
     LokiFsAdapter.prototype.loadDatabase = function loadDatabase (dbname, callback){
-      console.log('FS loading',dbname, __dirname) //####
       this.fs.readFile(dbname, { encoding: 'utf8' }, function readFileCallback(err, data) {
             if (err) {
                throw err;
@@ -782,7 +781,6 @@
      * @param {function} callback - the callback to handle the result
      */
     LokiFsAdapter.prototype.saveDatabase = function saveDatabase (dbname, dbstring, callback){
-      console.log('FS saving',dbname); //####
       this.fs.writeFile(dbname, dbstring, callback);
     };
     

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,3 +5,4 @@ require('./changesApi');
 require('./testCollection');
 require('./nodePersistence');
 require('./testRemove');
+require('./testCryptedFileAdapter');

--- a/tests/nodePersistence.js
+++ b/tests/nodePersistence.js
@@ -10,13 +10,13 @@ users.insert([{
 	name: 'jack'
 }]);
 
-db.saveDatabase();
+db.saveDatabase( function reload(){
 
 var reloaded = new loki('./loki.json');
-reloaded.loadDatabase({}, function () {
-	var users2 = reloaded.getCollection('users');
-	suite.assertEqual('There are 2 objects in the reloaded db', 2, users2.data.length);
-	suite.report();
+	reloaded.loadDatabase({}, function () {
+		var users2 = reloaded.getCollection('users');
+		suite.assertEqual('There are 2 objects in the reloaded db', 2, users2.data.length);
+		suite.report();
+		require('fs').unlink('./loki.json');
+	});
 });
-
-require('fs').unlink('./loki.json');

--- a/tests/testCryptedFileAdapter.js
+++ b/tests/testCryptedFileAdapter.js
@@ -1,0 +1,25 @@
+var cryptedFileAdapter = require('../src/lokiCryptedFileAdapter');
+
+cryptedFileAdapter.setSecret('mySecret');
+	
+var loki = require('../src/lokijs.js'),
+	db = new loki('./loki.json.crypted',{ adapter: cryptedFileAdapter }),
+	gordian = require('gordian'),
+	suite = new gordian('testCryptedFileAdapter'),
+	users = db.addCollection('users');
+
+users.insert([{
+	name: 'joe'
+}, {
+	name: 'jack'
+}]);
+
+db.saveDatabase( function reload(){
+	var reloaded = new loki('./loki.json.crypted',{ adapter: cryptedFileAdapter });
+	reloaded.loadDatabase({}, function () {
+		var users2 = reloaded.getCollection('users');
+		suite.assertEqual('There are 2 objects in the reloaded and decrypted db', 2, users2.data.length);
+		suite.report();
+		require('fs').unlink('./loki.json.crypted');
+	});
+});


### PR DESCRIPTION
Hi,

a PR with the refactored built-in persistence adapters.
The number of lines have increased but thats due to extra comments blocks. The double code is out now.

In short:
- added the "LokiFsAdapter" and "LokiLocalStorageAdapter" classes and refactored loadDatabase and saveDatabase to use them.

- rewired Loki.prototype.configureOptions to configure the right adapter

- modified the constructor to always call Loki.prototype.configureOptions so the right adapter is assigned.
(could have moved the defaults assignment back into the constructor but that would require the persistenceMethods definition to be available both in the constructor and in configureOptions

- modified test/nodePersistence.js to avoid race conditions if the test tries to reload while the save is not finished yet.

npm test succeeds
 
Hope you like it :-)

Hans

