### PR TITLE
Refactored event emitter 

### DIFF
--- a/benchmark/run.html
+++ b/benchmark/run.html
@@ -10,14 +10,15 @@
 <button id="runTaffy">run Taffy</button>
 <button id="runLoki">run Loki</button>
 <button id="runNeDB">run NeDB</button>
+<button id="runRaw">run raw array insert</button>
 <script type="text/javascript">
 
 document.getElementById('runLoki').addEventListener('click', runLokiBenchmark);
 document.getElementById('runTaffy').addEventListener('click', runTaffyBenchmark);
 document.getElementById('runNeDB').addEventListener('click', runNeDBBenchmark);
+document.getElementById('runRaw').addEventListener('click', runRawBenchmark);
 
-
-var size = 1000;
+var size = 100000;
 
 var generateData = function(size){
 
@@ -79,7 +80,20 @@ function runLokiBenchmark(){
 	var j = size;
 	console.profile('Profiling Loki');
 	while(j--){
-		lokis.document(coll[j]);
+		lokis.insert(coll[j]);
+	}
+	console.trace();
+	console.profileEnd();
+}
+
+function runRawBenchmark(){
+	// initialize loki
+	var db = [];
+
+	var j = size;
+	console.profile('Profiling Raw');
+	while(j--){
+		db.push(coll[j]);
 	}
 	console.trace();
 	console.profileEnd();

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -233,27 +233,22 @@
     }
 
     /**
-     * @propt emit(eventName, varargs) - emits a particular event
+     * @propt emit(eventName, data) - emits a particular event
      * with the option of passing optional parameters which are going to be processed by the callback
      * provided signatures match (i.e. if passing emit(event, arg0, arg1) the listener should take two parameters)
      * @param {string} eventName - the name of the event
-     * @param {object} varargs - optional objects passed with the event
+     * @param {object} data - optional object passed with the event
      */
-    LokiEventEmitter.prototype.emit = function (eventName) {
-
-      var args = Array.prototype.slice.call(arguments, 0),
-        self = this;
+    LokiEventEmitter.prototype.emit = function (eventName,data) {
+      var self = this;
       if (eventName && this.events[eventName]) {
-        args.splice(0, 1);
         this.events[eventName].forEach(function (listener) {
-
           if (self.asyncListeners) {
             setTimeout(function () {
-
-              applyListener(listener, args);
+              listener(data);
             }, 1);
           } else {
-            applyListener(listener, args);
+             listener(data);
           }
 
         });

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -228,10 +228,6 @@
       return listener;
     };
 
-    function applyListener(listener, args) {
-      listener.apply(null, args);
-    }
-
     /**
      * @propt emit(eventName, data) - emits a particular event
      * with the option of passing optional parameters which are going to be processed by the callback


### PR DESCRIPTION
Hi Joe,

refactored event emitter so the JIT can optimize it.
As all the emits in lokijs.js  have either 0 or 1 args there is no need for varargs. 

Also native call ( e.g. f(data))  is faster than apply ( f.apply(null,data)) , see http://jsperf.com/function-calls-direct-vs-apply-vs-call-vs-bind/6 for details.

100K inserts went from 328ms to 178ms on my i7 using Chrome 41 :-)

Second commit is a fix to make the benchmark work again and set its default size to 100K inserts.

Enjoy,
Hans