### PR TITLE
RFC: Make the tests run in a browser

### DIFF
--- a/benchmark.html
+++ b/benchmark.html
@@ -1,0 +1,2 @@
+<script src="src/lokijs.js"></script>
+<script src="benchmark/benchmark.js"></script>

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,11 +1,11 @@
-var loki = require('../src/lokijs.js'),
-	db = new loki('perftest'),
+// var loki = require('../src/lokijs.js'),
+var db = new loki('perftest'),
     samplecoll = null,
     arraySize = 5000,			// how large of a dataset to generate
     totalIterations = 20000,	// how many times we search it
     results = [],
 	getIterations = 2000000;	// get is crazy fast due to binary search so this needs separate scale
-  
+
 function genRandomVal()
 {
     var text = "";
@@ -19,47 +19,48 @@ function genRandomVal()
 
 // in addition to the loki id we will create a key of our own
 // (customId) which is number from 1- totalIterations
-// we will later perform find() queries against customId with and 
+// we will later perform find() queries against customId with and
 // without an index
 
 function initializeDB() {
 	db = new loki('perftest');
-  
+
 	var start, end, totalTime;
 	var totalTimes = [];
 	var totalMS = 0.0;
 
-	samplecoll = db.addCollection('samplecoll');  
+	samplecoll = db.addCollection('samplecoll');
   /*
     {
       asyncListeners: true,
       disableChangesApi: true,
       transactional: false,
-      clone: false 
+      clone: false
     }
-  ); 
+  );
   */
-    
+
 	for (var idx=0; idx < arraySize; idx++) {
    	var v1 = genRandomVal();
     var v2 = genRandomVal();
-    
-		start = process.hrtime();
-    	samplecoll.insert({ 
-			customId: idx, 
-			val: v1, 
-			val2: v2, 
+
+		// start = process.hrtime();
+    start = performance.now();
+    	samplecoll.insert({
+			customId: idx,
+			val: v1,
+			val2: v2,
 			val3: "more data 1234567890"
 		});
-		end = process.hrtime(start);
- 		totalTimes.push(end);
+		end = performance.now() - start;
+ 		totalTimes.push([0, end * 1e6]);
    }
-    
+
 	for(var idx=0; idx < totalTimes.length; idx++) {
 		totalMS += totalTimes[idx][0] * 1e3 + totalTimes[idx][1]/1e6;
 	}
-	
-    
+
+
 	//var totalMS = end[0] * 1e3 + end[1]/1e6;
 	totalMS = totalMS.toFixed(2);
 	var rate = arraySize * 1000 / totalMS;
@@ -74,12 +75,12 @@ function initializeDB() {
  */
 function initializeWithEval() {
 	var dbTest = new loki('perfInsertWithEval');
-  
+
 	var start, end, totalTime;
 	var totalTimes = [];
 	var totalMS = 0.0;
 
-	var coll = dbTest.addCollection('samplecoll', 
+	var coll = dbTest.addCollection('samplecoll',
     {
       indices: ['customId'],
       asyncListeners: false,
@@ -88,25 +89,27 @@ function initializeWithEval() {
       clone: false
     }
   );
-  
+
   var dv = coll.addDynamicView('test');
   dv.applyFind({'customId': {'$lt': arraySize/4 }});
-    
+
 	for (var idx=0; idx < arraySize; idx++) {
     var v1 = genRandomVal();
     var v2 = genRandomVal();
-    
-		start = process.hrtime();
-   	coll.insert({ 
-			customId: idx, 
-			val: v1, 
-			val2: v2, 
+
+		// start = process.hrtime();
+    start = performance.now();
+   	coll.insert({
+			customId: idx,
+			val: v1,
+			val2: v2,
 			val3: "more data 1234567890"
 		});
-		end = process.hrtime(start);
- 		totalTimes.push(end);
+		// end = process.hrtime(start);
+    end = performance.now() - start;
+ 		totalTimes.push([0, end * 1e6]);
    }
-    
+
 	for(var idx=0; idx < totalTimes.length; idx++) {
 		totalMS += totalTimes[idx][0] * 1e3 + totalTimes[idx][1]/1e6;
 	}
@@ -121,20 +124,22 @@ function testperfGet() {
 	var start, end;
 	var totalTimes = [];
 	var totalMS = 0.0;
-	
+
 	for (var idx=0; idx < getIterations; idx++) {
     	var customidx = Math.floor(Math.random() * arraySize) + 1;
-        
-		start = process.hrtime();
+
+		// start = process.hrtime();
+    start = performance.now();
         var results = samplecoll.get(customidx);
-		end = process.hrtime(start);
-		totalTimes.push(end);
+		// end = process.hrtime(start);
+    end = performance.now() - start;
+		totalTimes.push([0, end * 1e6]);
     }
-    
+
 	for(var idx=0; idx < totalTimes.length; idx++) {
 		totalMS += totalTimes[idx][0] * 1e3 + totalTimes[idx][1]/1e6;
 	}
-	
+
 	totalMS = totalMS.toFixed(2);
 	var rate = getIterations * 1000 / totalMS;
 	rate = rate.toFixed(2);
@@ -150,20 +155,22 @@ function testperfFind(multiplier) {
 	if (typeof(multiplier) != "undefined") {
 		loopIterations = loopIterations * multiplier;
 	}
-	
+
 	for (var idx=0; idx < loopIterations; idx++) {
     	var customidx = Math.floor(Math.random() * arraySize) + 1;
-        
-		start = process.hrtime();
+
+		// start = process.hrtime();
+    start = performance.now();
         var results = samplecoll.find({ 'customId': customidx });
-		end = process.hrtime(start);
-		totalTimes.push(end);
+		// end = process.hrtime(start);
+    end = performance.now() - start;
+		totalTimes.push([0, end * 1e6]);
     }
-    
+
 	for(var idx=0; idx < totalTimes.length; idx++) {
 		totalMS += totalTimes[idx][0] * 1e3 + totalTimes[idx][1]/1e6;
 	}
-	
+
 	totalMS = totalMS.toFixed(2);
 	var rate = loopIterations * 1000 / totalMS;
 	rate = rate.toFixed(2);
@@ -179,20 +186,22 @@ function testperfRS(multiplier) {
 	if (typeof(multiplier) != "undefined") {
 		loopIterations = loopIterations * multiplier;
 	}
-	
+
 	for (var idx=0; idx < loopIterations; idx++) {
     	var customidx = Math.floor(Math.random() * arraySize) + 1;
-        
-		start = process.hrtime();
+
+		// start = process.hrtime();
+    start = performance.now();
         var results = samplecoll.chain().find({ 'customId': customidx }).data();
-		end = process.hrtime(start)
-		totalTimes.push(end);
+		// end = process.hrtime(start)
+    end = performance.now() - start;
+		totalTimes.push([0, end * 1e6]);
     }
-    
+
 	for(var idx=0; idx < totalTimes.length; idx++) {
 		totalMS += totalTimes[idx][0] * 1e3 + totalTimes[idx][1]/1e6;
 	}
-	
+
 	totalMS = totalMS.toFixed(2);
 	var rate = loopIterations * 1000 / totalMS;
 	rate = rate.toFixed(2);
@@ -206,43 +215,47 @@ function testperfDV(multiplier) {
 	var totalTimes2 = [];
 	var totalMS = 0;
 	var totalMS2 = 0;
-    
+
 	var loopIterations = totalIterations;
 	if (typeof(multiplier) != "undefined") {
 		loopIterations = loopIterations * multiplier;
 	}
-	
+
 	for (var idx=0; idx < loopIterations; idx++) {
     	var customidx = Math.floor(Math.random() * arraySize) + 1;
-       
-		start = process.hrtime();
+
+		// start = process.hrtime();
+    start = performance.now();
 		var dv = samplecoll.addDynamicView("perfview");
         dv.applyFind({ 'customId': customidx });
         var results = dv.data();
-		end = process.hrtime(start);
-		totalTimes.push(end);
-      
+		// end = process.hrtime(start);
+    end = performance.now() - start;
+		totalTimes.push([0, end * 1e6]);
+
       	// test speed of repeated query on an already set up dynamicview
-      	start2 = process.hrtime();
+      	// start2 = process.hrtime();
+        start2 = performance.now();
         var results = dv.data();
-        end2 = process.hrtime(start2);
-		totalTimes2.push(end2);
-        
+        // end2 = process.hrtime(start2);
+        end2 = performance.now() - start2;
+		totalTimes2.push([0, end2 * 1e6]);
+
         samplecoll.removeDynamicView("perfview");
     }
-    
+
 	for(var idx=0; idx < totalTimes.length; idx++) {
 		totalMS += totalTimes[idx][0] * 1e3 + totalTimes[idx][1]/1e6;
 		totalMS2 += totalTimes2[idx][0] * 1e3 + totalTimes2[idx][1]/1e6;
 	}
-	
+
 	totalMS = totalMS.toFixed(2);
 	totalMS2 = totalMS2.toFixed(2);
 	var rate = loopIterations * 1000 / totalMS;
 	var rate2 = loopIterations * 1000 / totalMS2;
 	rate = rate.toFixed(2);
 	rate2 = rate2.toFixed(2);
-	
+
 	console.log("loki dynamic view first find : " + totalMS + "ms (" + rate + " ops/s) " + loopIterations + " iterations");
 	console.log("loki dynamic view subsequent finds : " + totalMS2 + "ms (" + rate2 + " ops/s) " + loopIterations + " iterations");
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,69 @@
+// Karma configuration
+// Generated on Wed Mar 25 2015 21:28:22 GMT+0000 (GMT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'src/lokijs.js',
+      'tests/helper.js',
+      'tests/*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['dots'],
+
+
+    // web server port
+    port: 9876,
+
+    hostname: '0.0.0.0',
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "test": "make test && istanbul cover tests/"
   },
   "author": "Joe Minichino <joe.minichino@gmail.com>",
-  "contributors": [{
-    "name": "Dave",
-    "email": "admin@obeliskos.com"
-  }],
+  "contributors": [
+    {
+      "name": "Dave",
+      "email": "admin@obeliskos.com"
+    }
+  ],
   "license": "BSD",
   "bugs": {
     "url": "https://github.com/techfort/LokiJS/issues"
@@ -39,6 +41,7 @@
     "gulp-concat": "^2.4.1",
     "gulp-uglify": "^1.0.1",
     "istanbul": "^0.3.2",
+    "karma-phantomjs-launcher": "^0.1.4",
     "mocha": "^2.0.1",
     "should": "^4.3.0",
     "uglify-js": "^2.4.15"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-uglify": "^1.0.1",
     "istanbul": "^0.3.2",
     "karma": "^0.12.31",
+    "karma-cli": "0.0.4",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "mocha": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "in-memory"
   ],
   "scripts": {
-    "test": "make test && istanbul cover tests/"
+    "test": "karma start karma.conf.js --single-run"
   },
   "author": "Joe Minichino <joe.minichino@gmail.com>",
   "contributors": [
@@ -41,8 +41,11 @@
     "gulp-concat": "^2.4.1",
     "gulp-uglify": "^1.0.1",
     "istanbul": "^0.3.2",
+    "karma": "^0.12.31",
+    "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "mocha": "^2.0.1",
+    "phantomjs": "^1.9.16",
     "should": "^4.3.0",
     "uglify-js": "^2.4.15"
   }

--- a/tests/changesApi.js
+++ b/tests/changesApi.js
@@ -1,46 +1,56 @@
-var loki = require('../src/lokijs.js'),
-	db = new loki(),
-	gordian = require('gordian'),
-	suite = new gordian('testEvents'),
-	options = {
-		asyncListeners: false,
-		disableChangesApi: false
-	},
-	users = db.addCollection('users', options),
-	test = db.addCollection('test', options),
-	test2 = db.addCollection('test2', options);
+// var loki = require('../src/lokijs.js'),
+describe('changesApi', function() {
+  it('does what it says on the tin', function() {
+    var db = new loki(),
+    // gordian = require('gordian'),
+    // suite = new gordian('testEvents'),
+    options = {
+      asyncListeners: false,
+      disableChangesApi: false
+    },
+    users = db.addCollection('users', options),
+    test = db.addCollection('test', options),
+    test2 = db.addCollection('test2', options);
 
-var u = users.insert({
-	name: 'joe'
-});
-u.name = 'jack';
-users.update(u);
-test.insert({
-	name: 'test'
-});
-test2.insert({
-	name: 'test2'
-});
+    var u = users.insert({
+      name: 'joe'
+    });
+    u.name = 'jack';
+    users.update(u);
+    test.insert({
+      name: 'test'
+    });
+    test2.insert({
+      name: 'test2'
+    });
 
-var userChanges = db.generateChangesNotification(['users']);
-suite.assertEqual('Single collection changes', 2, userChanges.length);
-suite.assertEqual('Check serialized changes', db.serializeChanges(['users']), JSON.stringify(userChanges));
-var someChanges = db.generateChangesNotification(['users', 'test2']);
-suite.assertEqual('Changes number for selected collections', 3, someChanges.length);
-var allChanges = db.generateChangesNotification();
-suite.assertEqual('Changes number for all collections', 4, allChanges.length);
-users.setChangesApi(false);
-suite.assertEqual('Changes Api disabled', true, users.disableChangesApi);
-u.name = 'john';
-users.update(u);
-var newChanges = db.generateChangesNotification(['users']);
-suite.assertEqual('Change should not register after Api disabled', 2, newChanges.length);
-db.clearChanges();
-suite.assertEqual('clearChanges should wipe changes', 0, users.getChanges().length);
+    var userChanges = db.generateChangesNotification(['users']);
 
-u.name = 'jim';
-users.update(u);
-users.flushChanges();
-suite.assertEqual('Collection level changes flush', 0, users.getChanges().length);
+    suite.assertEqual('Single collection changes', 2, userChanges.length);
+    suite.assertEqual('Check serialized changes', db.serializeChanges(['users']), JSON.stringify(userChanges));
 
-suite.report();
+    var someChanges = db.generateChangesNotification(['users', 'test2']);
+
+    suite.assertEqual('Changes number for selected collections', 3, someChanges.length);
+    var allChanges = db.generateChangesNotification();
+
+    suite.assertEqual('Changes number for all collections', 4, allChanges.length);
+    users.setChangesApi(false);
+    suite.assertEqual('Changes Api disabled', true, users.disableChangesApi);
+
+    u.name = 'john';
+    users.update(u);
+    var newChanges = db.generateChangesNotification(['users']);
+
+    suite.assertEqual('Change should not register after Api disabled', 2, newChanges.length);
+    db.clearChanges();
+
+    suite.assertEqual('clearChanges should wipe changes', 0, users.getChanges().length);
+
+    u.name = 'jim';
+    users.update(u);
+    users.flushChanges();
+
+    suite.assertEqual('Collection level changes flush', 0, users.getChanges().length);
+  })
+})

--- a/tests/eventEmitter.js
+++ b/tests/eventEmitter.js
@@ -1,37 +1,43 @@
-var loki = require('../src/lokijs.js'),
-  db = new loki('test', {
-    persistenceMethod: null
-  }),
-  gordian = require('gordian'),
-  suite = new gordian('testEvents'),
-  users = db.addCollection('users', {
-    asyncListeners: false
+// var loki = require('../src/lokijs.js'),
+describe('eventEmitter', function() {
+  var db;
+
+  beforeEach(function() {
+    db = new loki('test', {
+      persistenceMethod: null
+    }),
+    // gordian = require('gordian'),
+    // suite = new gordian('testEvents'),
+    users = db.addCollection('users', {
+      asyncListeners: false
+    });
+
+    users.insert({
+      name: 'joe'
+    });
+  })
+
+  it('async', function testAsync() {
+    suite.assertEqual('DB events async', db.asyncListeners, false);
   });
 
-users.insert({
-  name: 'joe'
-});
+  it('emit', function() {
+    var index = db.on('test', function test(obj) {
+      suite.assertEqual('Argument passed to event', 42, obj);
+    });
 
-function testAsync() {
-  suite.assertEqual('DB events async', db.asyncListeners, false);
-}
+    db.emit('test', 42);
+    db.removeListener('test', index);
 
-function testEmit() {
-  var index = db.on('test', function test(obj) {
-    suite.assertEqual('Argument passed to event', 42, obj);
-  });
+    suite.assertEqual('Event has no listeners attached', db.events['test'].length, 0);
 
-  db.emit('test', 42);
-  db.removeListener('test', index);
+    suite.assertThrows('No event testEvent', function testEvent() {
+      db.emit('testEvent');
+    }, Error);
+  })
+})
 
-  suite.assertEqual('Event has no listeners attached', db.events['test'].length, 0);
+// testAsync();
+// testEmit();
 
-  suite.assertThrows('No event testEvent', function testEvent() {
-    db.emit('testEvent');
-  }, Error);
-}
-
-testAsync();
-testEmit();
-
-suite.report();
+// suite.report();

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -1,0 +1,21 @@
+var suite = {
+  assertEqual: function(message, actual, expected) {
+    expect(actual).toEqual(expected);
+  },
+
+  assertNotEqual: function(message, actual, expected) {
+    expect(actual).not.toEqual(expected);
+  },
+
+  assertStrictEqual: function(message, actual, expected) {
+    expect(actual).toBe(expected);
+  },
+
+  assertNotStrictEqual: function(message, actual, expected) {
+    expect(actual).not.toBe(expected);
+  },
+
+  assertThrows: function(message, fn) {
+    expect(fn).toThrow();
+  }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,11 +1,11 @@
-require('./test');
-require('./testTyped');
-require('./eventEmitter');
-require('./changesApi');
-require('./testCollection');
-require('./nodePersistence');
-require('./testRemove');
-require('./testCryptedFileAdapter');
-require('./testStats');
-require('./joins');
+// require('./test');
+// require('./testTyped');
+// require('./eventEmitter');
+// require('./changesApi');
+// require('./testCollection');
+// require('./nodePersistence');
+// require('./testRemove');
+// require('./testCryptedFileAdapter');
+// require('./testStats');
+// require('./joins');
 

--- a/tests/joins.js
+++ b/tests/joins.js
@@ -1,28 +1,32 @@
-var Loki = require('../src/lokijs.js'),
-  gordian = require('gordian'),
-  suite = new gordian('testJoins'),
-  db = new Loki('testJoins', {
-    persistenceMethod: null
-  }),
-  directors = db.addCollection('directors'),
-  films = db.addCollection('films');
+describe('joins', function() {
+  var db, directors, films;
 
-directors.insert([
-  {name: 'Martin Scorsese', directorId: 1},
-  {name: 'Francis Ford Coppola', directorId: 2},
-  {name: 'Steven Spielberg', directorId: 3},
-  {name: 'Quentin Tarantino', directorId: 4}
-]);
+  beforeEach(function() {
+      db = new loki('testJoins', {
+        persistenceMethod: null
+      }),
+      directors = db.addCollection('directors'),
+      films = db.addCollection('films');
 
-films.insert([
-  {title: 'Taxi', filmId: 1, directorId: 1},
-  {title: 'Raging Bull', filmId: 2, directorId: 1},
-  {title: 'The Godfather', filmId: 3, directorId: 2},
-  {title: 'Jaws', filmId: 4, directorId: 3},
-  {title: 'ET', filmId: 5, directorId: 3},
-  {title: 'Raiders of the Lost Ark', filmId: 6, directorId: 3}
-]);
-var joined;
+    directors.insert([
+      {name: 'Martin Scorsese', directorId: 1},
+      {name: 'Francis Ford Coppola', directorId: 2},
+      {name: 'Steven Spielberg', directorId: 3},
+      {name: 'Quentin Tarantino', directorId: 4}
+    ]);
+
+    films.insert([
+      {title: 'Taxi', filmId: 1, directorId: 1},
+      {title: 'Raging Bull', filmId: 2, directorId: 1},
+      {title: 'The Godfather', filmId: 3, directorId: 2},
+      {title: 'Jaws', filmId: 4, directorId: 3},
+      {title: 'ET', filmId: 5, directorId: 3},
+      {title: 'Raiders of the Lost Ark', filmId: 6, directorId: 3}
+    ]);
+  })
+
+  it('works', function() {
+    var joined;
 
 //Basic non-mapped join
 joined = films.eqJoin(directors.data, 'directorId', 'directorId').data();
@@ -75,5 +79,12 @@ joined = films.chain().eqJoin(directors.data,
   .data();
 
 suite.assertEqual('calculated join works', joined[0].right.name, 'Steven Spielberg');
+  })
+})
+// var Loki = require('../src/lokijs.js'),
+//   gordian = require('gordian'),
+//   suite = new gordian('testJoins'),
 
-suite.report();
+
+
+// suite.report();

--- a/tests/nodePersistence.js
+++ b/tests/nodePersistence.js
@@ -1,40 +1,40 @@
-var loki = require('../src/lokijs.js'),
-	db = new loki('./loki.json'),
-	gordian = require('gordian'),
-	suite = new gordian('nodePersistence'),
-	users = db.addCollection('users');
+// var loki = require('../src/lokijs.js'),
+// 	db = new loki('./loki.json'),
+// 	gordian = require('gordian'),
+// 	suite = new gordian('nodePersistence'),
+// 	users = db.addCollection('users');
 
-users.insert([{
-	name: 'joe'
-}, {
-	name: 'jack'
-}]);
+// users.insert([{
+// 	name: 'joe'
+// }, {
+// 	name: 'jack'
+// }]);
 
-db.saveDatabase( function reload(){
+// db.saveDatabase( function reload(){
 
-var reloaded = new loki('./loki.json');
-	reloaded.loadDatabase({}, function () {
-		var users2 = reloaded.getCollection('users');
-		suite.assertEqual('There are 2 objects in the reloaded db', 2, users2.data.length);
-		require('fs').unlink('./loki.json');
-	});
-});
+// var reloaded = new loki('./loki.json');
+// 	reloaded.loadDatabase({}, function () {
+// 		var users2 = reloaded.getCollection('users');
+// 		suite.assertEqual('There are 2 objects in the reloaded db', 2, users2.data.length);
+// 		require('fs').unlink('./loki.json');
+// 	});
+// });
 
-// test autoload callback fires even when database does not exist
-function testAutoLoad() {
-	var cbSuccess = false;
+// // test autoload callback fires even when database does not exist
+// function testAutoLoad() {
+// 	var cbSuccess = false;
 
-	var tdb = new loki('nonexistent.db', 
-	{
-        autoload: true,
-        autoloadCallback : function() { cbSuccess = true; }
-    }); 
+// 	var tdb = new loki('nonexistent.db',
+// 	{
+//         autoload: true,
+//         autoloadCallback : function() { cbSuccess = true; }
+//     });
 
-	setTimeout(function() {
-		suite.assertEqual('autoload callback was called', cbSuccess, true);
-		suite.report();
-	}, 500);
-}
+// 	setTimeout(function() {
+// 		suite.assertEqual('autoload callback was called', cbSuccess, true);
+// 		suite.report();
+// 	}, 500);
+// }
 
-// due to async nature of top inline test, give it some time to complete
-setTimeout(testAutoLoad, 500);
+// // due to async nature of top inline test, give it some time to complete
+// setTimeout(testAutoLoad, 500);

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,9 +1,11 @@
 // to be run in node
-var gordian = require('gordian'),
-  suite = new gordian('LokiTests'),
-  loki = require('../src/lokijs.js'),
-  db,
-  users;
+// var gordian = require('gordian'),
+  // suite = new gordian('LokiTests'),
+  // loki = require('../src/lokijs.js'),
+describe('loki', function() {
+var db,
+  users,
+  jonas;
 
 function docCompare(a, b) {
   if (a.$loki < b.$loki) return -1;
@@ -12,501 +14,511 @@ function docCompare(a, b) {
   return 0;
 }
 
-db = new loki('test.json');
+beforeEach(function() {
+  db = new loki('test.json');
 users = db.addCollection('user');
-var jonas = null;
 
-function populateTestData() {
+users.insert({
+  name: 'dave',
+  age: 25,
+  lang: 'English'
+});
 
-  users.insert({
-    name: 'dave',
-    age: 25,
-    lang: 'English'
-  });
+users.insert({
+  name: 'joe',
+  age: 39,
+  lang: 'Italian'
+});
 
-  users.insert({
-    name: 'joe',
-    age: 39,
-    lang: 'Italian'
-  });
+jonas = users.insert({
+  name: 'jonas',
+  age: 30,
+  lang: 'Swedish'
+});
+})
 
-  jonas = users.insert({
-    name: 'jonas',
-    age: 30,
-    lang: 'Swedish'
-  });
 
-}
+describe('core methods', function() {
+  it('works', function() {
+    // findOne()
+    var j = users.findOne({
+      'name': 'jonas'
+    });
+    suite.assertStrictEqual("findOne", j.name, 'jonas');
 
-function testCoreMethods() {
-  // findOne()
-  var j = users.findOne({
-    'name': 'jonas'
-  });
-  suite.assertStrictEqual("findOne", j.name, 'jonas');
+    // find()
+    var result = users.find({
+      'age': {
+        '$gt': 29
+      }
+    });
+    suite.assertStrictEqual("find", result.length, 2);
 
-  // find()
-  var result = users.find({
-    'age': {
-      '$gt': 29
+    // $regex test
+    suite.assertStrictEqual('$regex', users.find({
+      "name": {
+        '$regex': /o/
+      }
+    }).length, 2);
+
+    // insert() : try inserting existing document (should fail), try adding doc with legacy id column
+    var collectionLength = users.data.length;
+    var objDave = users.findOne({
+      'name': 'dave'
+    });
+    var wasAdded = true;
+    try {
+      users.insert(objDave);
+    } catch (err) {
+      wasAdded = false;
     }
-  });
-  suite.assertStrictEqual("find", result.length, 2);
+    suite.assertStrictEqual('insert existing document caught', wasAdded, false);
 
-  // $regex test
-  suite.assertStrictEqual('$regex', users.find({
-    "name": {
-      '$regex': /o/
+    // our collections are not strongly typed so lets invent some object that has its 'own' id column
+    var legacyObject = {
+      id: 999,
+      first: 'aaa',
+      last: 'bbb',
+      city: 'pasadena',
+      state: 'ca'
     }
-  }).length, 2);
 
-  // insert() : try inserting existing document (should fail), try adding doc with legacy id column
-  var collectionLength = users.data.length;
-  var objDave = users.findOne({
-    'name': 'dave'
-  });
-  var wasAdded = true;
-  try {
-    users.insert(objDave);
-  } catch (err) {
-    wasAdded = false;
-  }
-  suite.assertStrictEqual('insert existing document caught', wasAdded, false);
+    wasAdded = true;
 
-  // our collections are not strongly typed so lets invent some object that has its 'own' id column
-  var legacyObject = {
-    id: 999,
-    first: 'aaa',
-    last: 'bbb',
-    city: 'pasadena',
-    state: 'ca'
-  }
-
-  wasAdded = true;
-
-  try {
-    users.insert(legacyObject);
-  } catch (err) {
-    wasAdded = false;
-  }
-
-  suite.assertStrictEqual('insert legacy document allowed', wasAdded, true);
-
-  // remove object so later queries access valid properties on all objects
-  if (wasAdded) {
-    users.remove(legacyObject); // the object itself should have been modified
-  }
-
-  // update()
-  legacyObject = {
-    id: 998,
-    first: 'aaa',
-    last: 'bbb',
-    city: 'pasadena',
-    state: 'ca'
-  }
-  var wasUpdated = true;
-
-  try {
-    users.update(legacyObject);
-  } catch (err) {
-    wasUpdated = false;
-  }
-  suite.assertStrictEqual('updating object not in collection should fail', wasUpdated, false);
-
-  // remove() - add some bogus object to remove
-  var userCount1 = users.data.length;
-
-  testObject = {
-    first: 'aaa',
-    last: 'bbb',
-    city: 'pasadena',
-    state: 'ca'
-  }
-
-  users.insert(testObject);
-
-  suite.assertStrictEqual('delete test : insert obj to delete', userCount1 + 1, users.data.length);
-  users.remove(testObject);
-  suite.assertStrictEqual('delete test : delete', userCount1, users.data.length);
-}
-
-function testCalculateRange() {
-  var eic = db.addCollection("eic");
-  eic.ensureIndex("testid");
-
-  eic.insert({
-    'testid': 1,
-    'testString': 'hhh',
-    'testFloat': 5.2
-  }); //0
-  eic.insert({
-    'testid': 1,
-    'testString': 'aaa',
-    'testFloat': 6.2
-  }); //1
-  eic.insert({
-    'testid': 5,
-    'testString': 'zzz',
-    'testFloat': 7.2
-  }); //2
-  eic.insert({
-    'testid': 6,
-    'testString': 'ggg',
-    'testFloat': 1.2
-  }); //3
-  eic.insert({
-    'testid': 9,
-    'testString': 'www',
-    'testFloat': 8.2
-  }); //4
-  eic.insert({
-    'testid': 11,
-    'testString': 'yyy',
-    'testFloat': 4.2
-  }); //5
-  eic.insert({
-    'testid': 22,
-    'testString': 'yyz',
-    'testFloat': 9.2
-  }); //6
-  eic.insert({
-    'testid': 23,
-    'testString': 'm',
-    'testFloat': 2.2
-  }); //7
-
-  var rset = eic.chain();
-  rset.find({
-    'testid': 1
-  }); // force index to be built
-
-  // ranges are order of sequence in index not data array positions
-
-  var range = rset.calculateRange('$eq', 'testid', 22);
-  suite.assertEqual('calculateRange $eq', range, [6, 6]);
-
-  range = rset.calculateRange('$eq', 'testid', 1);
-  suite.assertEqual('calculateRange $eq multiple', range, [0, 1]);
-
-  range = rset.calculateRange('$eq', 'testid', 7);
-  suite.assertEqual('calculateRange $eq not found', range, [0, -1]);
-
-  range = rset.calculateRange('$gte', 'testid', 23);
-  suite.assertEqual('calculateRange $gte', range, [7, 7]);
-
-  // reference this new record for future evaluations
-  eic.insert({
-    'testid': 23,
-    'testString': 'bbb',
-    'testFloat': 1.9
-  });
-
-  range = rset.calculateRange('$gte', 'testid', 23);
-  suite.assertEqual('calculateRange $gte', range, [7, 8]);
-
-  range = rset.calculateRange('$gte', 'testid', 24);
-  suite.assertEqual('calculateRange $gte out of range', range, [0, -1]);
-
-  range = rset.calculateRange('$lte', 'testid', 5);
-  suite.assertEqual('calculateRange $lte', range, [0, 2]);
-
-  range = rset.calculateRange('$lte', 'testid', 1);
-  suite.assertEqual('calculateRange $lte', range, [0, 1]);
-
-  range = rset.calculateRange('$lte', 'testid', -1);
-  suite.assertEqual('calculateRange $lte out of range', range, [0, -1]);
-
-  // add another index on string property
-  eic.ensureIndex('testString');
-  rset.find({
-    'testString': 'asdf'
-  }); // force index to be built
-
-  range = rset.calculateRange('$lte', 'testString', 'ggg');
-  suite.assertEqual('calculateRange $lte string', range, [0, 2]); // includes record added in middle
-
-  range = rset.calculateRange('$gte', 'testString', 'm');
-  suite.assertEqual('calculateRange $gte string', range, [4, 8]); // offset by 1 because of record in middle
-
-  // add some float range evaluations
-  eic.ensureIndex('testFloat');
-  rset.find({
-    'testFloat': '1.1'
-  }); // force index to be built
-
-  range = rset.calculateRange('$lte', 'testFloat', 1.2);
-  suite.assertEqual('calculateRange $lte float', range, [0, 0]);
-
-  range = rset.calculateRange('$eq', 'testFloat', 1.111);
-  suite.assertEqual('calculateRange $eq not found', range, [0, -1]);
-
-  range = rset.calculateRange('$eq', 'testFloat', 8.2);
-  suite.assertEqual('calculateRange $eq found', range, [7, 7]); // 8th pos
-
-  range = rset.calculateRange('$gte', 'testFloat', 1.0);
-  suite.assertEqual('calculateRange $gt all', range, [0, 8]); // 8th pos
-}
-
-function testIndexLifecycle() {
-  var ilc = db.addCollection('ilc');
-
-  var hasIdx = ilc.binaryIndices.hasOwnProperty('testid');
-  suite.assertEqual('index lifecycle before', hasIdx, false);
-
-  ilc.ensureIndex('testid');
-  hasIdx = ilc.binaryIndices.hasOwnProperty('testid');
-  suite.assertEqual('index lifecycle created', hasIdx, true);
-  suite.assertEqual('index lifecycle created', ilc.binaryIndices.testid.dirty, false);
-  suite.assertEqual('index lifecycle created', ilc.binaryIndices.testid.values, []);
-
-  ilc.insert({
-    'testid': 5
-  });
-  suite.assertEqual('index lifecycle dirty', ilc.binaryIndices.testid.dirty, true);
-  ilc.insert({
-    'testid': 8
-  });
-  suite.assertEqual('index lifecycle still lazy', ilc.binaryIndices.testid.values, []);
-  suite.assertEqual('index lifecycle still dirty', ilc.binaryIndices.testid.dirty, true);
-
-  ilc.find({
-    'testid': 8
-  }); // should force index build
-  suite.assertEqual('index lifecycle built', ilc.binaryIndices.testid.dirty, false);
-  suite.assertEqual('index lifecycle still lazy', ilc.binaryIndices.testid.values.length, 2);
-}
-
-function testIndexes() {
-  var itc = db.addCollection('test', {
-    indices: ['testid']
-  });
-
-  itc.insert({
-    'testid': 1
-  });
-  itc.insert({
-    'testid': 2
-  });
-  itc.insert({
-    'testid': 5
-  });
-  itc.insert({
-    'testid': 5
-  });
-  itc.insert({
-    'testid': 9
-  });
-  itc.insert({
-    'testid': 11
-  });
-  itc.insert({
-    'testid': 22
-  });
-  itc.insert({
-    'testid': 22
-  });
-
-  // lte
-  var results = itc.find({
-    'testid': {
-      '$lte': 1
+    try {
+      users.insert(legacyObject);
+    } catch (err) {
+      wasAdded = false;
     }
-  });
-  suite.assertStrictEqual('find using index $lte', results.length, 1);
 
-  results = itc.find({
-    'testid': {
-      '$lte': 22
+    suite.assertStrictEqual('insert legacy document allowed', wasAdded, true);
+
+    // remove object so later queries access valid properties on all objects
+    if (wasAdded) {
+      users.remove(legacyObject); // the object itself should have been modified
     }
-  });
-  suite.assertStrictEqual('find using index $lte', results.length, 8);
 
-  // lt
-  results = itc.find({
-    'testid': {
-      '$lt': 1
+    // update()
+    legacyObject = {
+      id: 998,
+      first: 'aaa',
+      last: 'bbb',
+      city: 'pasadena',
+      state: 'ca'
     }
-  });
-  suite.assertStrictEqual('find using index $lt', results.length, 0);
+    var wasUpdated = true;
 
-  results = itc.find({
-    'testid': {
-      '$lt': 22
+    try {
+      users.update(legacyObject);
+    } catch (err) {
+      wasUpdated = false;
     }
-  });
-  suite.assertStrictEqual('find using index $lt', results.length, 6);
+    suite.assertStrictEqual('updating object not in collection should fail', wasUpdated, false);
 
-  // eq
-  results = itc.find({
-    'testid': {
-      '$eq': 22
+    // remove() - add some bogus object to remove
+    var userCount1 = users.data.length;
+
+    testObject = {
+      first: 'aaa',
+      last: 'bbb',
+      city: 'pasadena',
+      state: 'ca'
     }
-  });
-  suite.assertStrictEqual('find using index $eq', results.length, 2);
 
-  // gt
-  results = itc.find({
-    'testid': {
-      '$gt': 22
-    }
-  });
-  suite.assertStrictEqual('find using index $eq', results.length, 0);
+    users.insert(testObject);
 
-  results = itc.find({
-    'testid': {
-      '$gt': 5
-    }
-  });
-  suite.assertStrictEqual('find using index $eq', results.length, 4);
+    suite.assertStrictEqual('delete test : insert obj to delete', userCount1 + 1, users.data.length);
+    users.remove(testObject);
+    suite.assertStrictEqual('delete test : delete', userCount1, users.data.length);
+  })
+});
 
-  // gte
-  results = itc.find({
-    'testid': {
-      '$gte': 5
-    }
-  });
-  suite.assertStrictEqual('find using index $gte', results.length, 6);
+describe('calculateRange', function() {
+  it('works', function() {
+    var eic = db.addCollection("eic");
+    eic.ensureIndex("testid");
 
-  results = itc.find({
-    'testid': {
-      '$gte': 10
-    }
-  });
-  suite.assertStrictEqual('find using index $gte', results.length, 3);
-}
+    eic.insert({
+      'testid': 1,
+      'testString': 'hhh',
+      'testFloat': 5.2
+    }); //0
+    eic.insert({
+      'testid': 1,
+      'testString': 'aaa',
+      'testFloat': 6.2
+    }); //1
+    eic.insert({
+      'testid': 5,
+      'testString': 'zzz',
+      'testFloat': 7.2
+    }); //2
+    eic.insert({
+      'testid': 6,
+      'testString': 'ggg',
+      'testFloat': 1.2
+    }); //3
+    eic.insert({
+      'testid': 9,
+      'testString': 'www',
+      'testFloat': 8.2
+    }); //4
+    eic.insert({
+      'testid': 11,
+      'testString': 'yyy',
+      'testFloat': 4.2
+    }); //5
+    eic.insert({
+      'testid': 22,
+      'testString': 'yyz',
+      'testFloat': 9.2
+    }); //6
+    eic.insert({
+      'testid': 23,
+      'testString': 'm',
+      'testFloat': 2.2
+    }); //7
 
-function testResultset() {
-  // Resultset find
-  suite.assertStrictEqual('Resultset (chained) find', users.chain().find({
-    'age': {
-      '$gte': 30
-    }
-  }).where(function (obj) {
-    return obj.lang === 'Swedish';
-  }).data().length, 1);
+    var rset = eic.chain();
+    rset.find({
+      'testid': 1
+    }); // force index to be built
 
-  // Resultset offset
-  suite.assertStrictEqual('Resultset (chained) offset', users.chain().offset(1).data().length, users.data.length - 1);
+    // ranges are order of sequence in index not data array positions
 
-  // Resultset limit
-  suite.assertStrictEqual('Resultset (chained) limit', users.chain().limit(2).data().length, 2);
+    var range = rset.calculateRange('$eq', 'testid', 22);
+    suite.assertEqual('calculateRange $eq', range, [6, 6]);
 
-}
+    range = rset.calculateRange('$eq', 'testid', 1);
+    suite.assertEqual('calculateRange $eq multiple', range, [0, 1]);
 
-function testAndOrOps() {
-  var eic = db.addCollection("eic");
+    range = rset.calculateRange('$eq', 'testid', 7);
+    suite.assertEqual('calculateRange $eq not found', range, [0, -1]);
 
-  eic.insert({
-    'testid': 1,
-    'testString': 'hhh',
-    'testFloat': 5.2
-  }); //0
-  eic.insert({
-    'testid': 1,
-    'testString': 'bbb',
-    'testFloat': 6.2
-  }); //1
-  eic.insert({
-    'testid': 5,
-    'testString': 'zzz',
-    'testFloat': 7.2
-  }); //2
-  eic.insert({
-    'testid': 6,
-    'testString': 'ggg',
-    'testFloat': 1.2
-  }); //3
-  eic.insert({
-    'testid': 9,
-    'testString': 'www',
-    'testFloat': 8.2
-  }); //4
-  eic.insert({
-    'testid': 11,
-    'testString': 'yyy',
-    'testFloat': 4.2
-  }); //5
-  eic.insert({
-    'testid': 22,
-    'testString': 'bbb',
-    'testFloat': 9.2
-  }); //6
-  eic.insert({
-    'testid': 23,
-    'testString': 'm',
-    'testFloat': 2.2
-  }); //7
+    range = rset.calculateRange('$gte', 'testid', 23);
+    suite.assertEqual('calculateRange $gte', range, [7, 7]);
 
-  // coll.find $and
-  suite.assertStrictEqual('$and op test1', eic.find({
-    '$and': [
-      {'testid': 1},
-      {'testString': 'bbb'}
-    ]
-  }).length, 1);
+    // reference this new record for future evaluations
+    eic.insert({
+      'testid': 23,
+      'testString': 'bbb',
+      'testFloat': 1.9
+    });
 
-  // resultset.find $and
-  suite.assertStrictEqual('$and op test2', eic.chain().find({
-    '$and': [
-      {'testid': 1},
-      {'testString': 'bbb'}
-    ]
-  }).data().length, 1);
+    range = rset.calculateRange('$gte', 'testid', 23);
+    suite.assertEqual('calculateRange $gte', range, [7, 8]);
 
-  // resultset.find explicit operators
-  suite.assertStrictEqual('$and op test3', eic.chain().find({
-    '$and': [
-      {'testid': {'$eq': 1}},
-      {'testFloat': {'$gt': 6.0}}
-    ]
-  }).data().length, 1);
+    range = rset.calculateRange('$gte', 'testid', 24);
+    suite.assertEqual('calculateRange $gte out of range', range, [0, -1]);
 
-  // coll.find $or
-  suite.assertStrictEqual('$or op test1', eic.find({
-    '$or': [
-      {'testid': 1},
-      {'testString': 'bbb'}
-    ]
-  }).length, 3);
+    range = rset.calculateRange('$lte', 'testid', 5);
+    suite.assertEqual('calculateRange $lte', range, [0, 2]);
 
-  // resultset.find $or
-  suite.assertStrictEqual('$or op test2', eic.chain().find({
-    '$or': [
-      {'testid': 1},
-      {'testString': 'bbb'}
-    ]
-  }).data().length, 3);
+    range = rset.calculateRange('$lte', 'testid', 1);
+    suite.assertEqual('calculateRange $lte', range, [0, 1]);
 
-  // resultset.find explicit operators
-  suite.assertStrictEqual('$or op test3', eic.chain().find({
-    '$or': [
-      {'testid': 1},
-      {'testFloat': {'$gt': 7.0}}
-    ]
-  }).data().length, 5);
+    range = rset.calculateRange('$lte', 'testid', -1);
+    suite.assertEqual('calculateRange $lte out of range', range, [0, -1]);
 
-  // add index and repeat final test
-  eic.ensureIndex("testid");
+    // add another index on string property
+    eic.ensureIndex('testString');
+    rset.find({
+      'testString': 'asdf'
+    }); // force index to be built
 
-  suite.assertStrictEqual('$and op test4', eic.chain().find({
-    '$and': [
-      {'testid': {'$eq': 1}},
-      {'testFloat': {'$gt': 6.0}}
-    ]
-  }).data().length, 1);
+    range = rset.calculateRange('$lte', 'testString', 'ggg');
+    suite.assertEqual('calculateRange $lte string', range, [0, 2]); // includes record added in middle
 
-  suite.assertStrictEqual('$or op test4', eic.chain().find({
-    '$or': [
-      {'testid': 1},
-      {'testFloat': {'$gt': 7.0}}
-    ]
-  }).data().length, 5);
+    range = rset.calculateRange('$gte', 'testString', 'm');
+    suite.assertEqual('calculateRange $gte string', range, [4, 8]); // offset by 1 because of record in middle
 
-  db.removeCollection("eic");
-}
+    // add some float range evaluations
+    eic.ensureIndex('testFloat');
+    rset.find({
+      'testFloat': '1.1'
+    }); // force index to be built
 
-function testFindOne() {
+    range = rset.calculateRange('$lte', 'testFloat', 1.2);
+    suite.assertEqual('calculateRange $lte float', range, [0, 0]);
+
+    range = rset.calculateRange('$eq', 'testFloat', 1.111);
+    suite.assertEqual('calculateRange $eq not found', range, [0, -1]);
+
+    range = rset.calculateRange('$eq', 'testFloat', 8.2);
+    suite.assertEqual('calculateRange $eq found', range, [7, 7]); // 8th pos
+
+    range = rset.calculateRange('$gte', 'testFloat', 1.0);
+    suite.assertEqual('calculateRange $gt all', range, [0, 8]); // 8th pos
+  })
+});
+
+describe('indexLifecycle', function() {
+  it('works', function () {
+    var ilc = db.addCollection('ilc');
+
+    var hasIdx = ilc.binaryIndices.hasOwnProperty('testid');
+    suite.assertEqual('index lifecycle before', hasIdx, false);
+
+    ilc.ensureIndex('testid');
+    hasIdx = ilc.binaryIndices.hasOwnProperty('testid');
+    suite.assertEqual('index lifecycle created', hasIdx, true);
+    suite.assertEqual('index lifecycle created', ilc.binaryIndices.testid.dirty, false);
+    suite.assertEqual('index lifecycle created', ilc.binaryIndices.testid.values, []);
+
+    ilc.insert({
+      'testid': 5
+    });
+    suite.assertEqual('index lifecycle dirty', ilc.binaryIndices.testid.dirty, true);
+    ilc.insert({
+      'testid': 8
+    });
+    suite.assertEqual('index lifecycle still lazy', ilc.binaryIndices.testid.values, []);
+    suite.assertEqual('index lifecycle still dirty', ilc.binaryIndices.testid.dirty, true);
+
+    ilc.find({
+      'testid': 8
+    }); // should force index build
+    suite.assertEqual('index lifecycle built', ilc.binaryIndices.testid.dirty, false);
+    suite.assertEqual('index lifecycle still lazy', ilc.binaryIndices.testid.values.length, 2);
+  })
+})
+
+describe('indexes', function() {
+  it('works', function() {
+    var itc = db.addCollection('test', {
+      indices: ['testid']
+    });
+
+    itc.insert({
+      'testid': 1
+    });
+    itc.insert({
+      'testid': 2
+    });
+    itc.insert({
+      'testid': 5
+    });
+    itc.insert({
+      'testid': 5
+    });
+    itc.insert({
+      'testid': 9
+    });
+    itc.insert({
+      'testid': 11
+    });
+    itc.insert({
+      'testid': 22
+    });
+    itc.insert({
+      'testid': 22
+    });
+
+    // lte
+    var results = itc.find({
+      'testid': {
+        '$lte': 1
+      }
+    });
+    suite.assertStrictEqual('find using index $lte', results.length, 1);
+
+    results = itc.find({
+      'testid': {
+        '$lte': 22
+      }
+    });
+    suite.assertStrictEqual('find using index $lte', results.length, 8);
+
+    // lt
+    results = itc.find({
+      'testid': {
+        '$lt': 1
+      }
+    });
+    suite.assertStrictEqual('find using index $lt', results.length, 0);
+
+    results = itc.find({
+      'testid': {
+        '$lt': 22
+      }
+    });
+    suite.assertStrictEqual('find using index $lt', results.length, 6);
+
+    // eq
+    results = itc.find({
+      'testid': {
+        '$eq': 22
+      }
+    });
+    suite.assertStrictEqual('find using index $eq', results.length, 2);
+
+    // gt
+    results = itc.find({
+      'testid': {
+        '$gt': 22
+      }
+    });
+    suite.assertStrictEqual('find using index $eq', results.length, 0);
+
+    results = itc.find({
+      'testid': {
+        '$gt': 5
+      }
+    });
+    suite.assertStrictEqual('find using index $eq', results.length, 4);
+
+    // gte
+    results = itc.find({
+      'testid': {
+        '$gte': 5
+      }
+    });
+    suite.assertStrictEqual('find using index $gte', results.length, 6);
+
+    results = itc.find({
+      'testid': {
+        '$gte': 10
+      }
+    });
+    suite.assertStrictEqual('find using index $gte', results.length, 3);
+  })
+})
+
+describe('resultSet', function() {
+  it('works', function() {
+    // Resultset find
+    suite.assertStrictEqual('Resultset (chained) find', users.chain().find({
+      'age': {
+        '$gte': 30
+      }
+    }).where(function (obj) {
+      return obj.lang === 'Swedish';
+    }).data().length, 1);
+
+    // Resultset offset
+    suite.assertStrictEqual('Resultset (chained) offset', users.chain().offset(1).data().length, users.data.length - 1);
+
+    // Resultset limit
+    suite.assertStrictEqual('Resultset (chained) limit', users.chain().limit(2).data().length, 2);
+  })
+})
+
+describe('andOrOps', function() {
+  it('works', function() {
+    var eic = db.addCollection("eic");
+
+    eic.insert({
+      'testid': 1,
+      'testString': 'hhh',
+      'testFloat': 5.2
+    }); //0
+    eic.insert({
+      'testid': 1,
+      'testString': 'bbb',
+      'testFloat': 6.2
+    }); //1
+    eic.insert({
+      'testid': 5,
+      'testString': 'zzz',
+      'testFloat': 7.2
+    }); //2
+    eic.insert({
+      'testid': 6,
+      'testString': 'ggg',
+      'testFloat': 1.2
+    }); //3
+    eic.insert({
+      'testid': 9,
+      'testString': 'www',
+      'testFloat': 8.2
+    }); //4
+    eic.insert({
+      'testid': 11,
+      'testString': 'yyy',
+      'testFloat': 4.2
+    }); //5
+    eic.insert({
+      'testid': 22,
+      'testString': 'bbb',
+      'testFloat': 9.2
+    }); //6
+    eic.insert({
+      'testid': 23,
+      'testString': 'm',
+      'testFloat': 2.2
+    }); //7
+
+    // coll.find $and
+    suite.assertStrictEqual('$and op test1', eic.find({
+      '$and': [
+        {'testid': 1},
+        {'testString': 'bbb'}
+      ]
+    }).length, 1);
+
+    // resultset.find $and
+    suite.assertStrictEqual('$and op test2', eic.chain().find({
+      '$and': [
+        {'testid': 1},
+        {'testString': 'bbb'}
+      ]
+    }).data().length, 1);
+
+    // resultset.find explicit operators
+    suite.assertStrictEqual('$and op test3', eic.chain().find({
+      '$and': [
+        {'testid': {'$eq': 1}},
+        {'testFloat': {'$gt': 6.0}}
+      ]
+    }).data().length, 1);
+
+    // coll.find $or
+    suite.assertStrictEqual('$or op test1', eic.find({
+      '$or': [
+        {'testid': 1},
+        {'testString': 'bbb'}
+      ]
+    }).length, 3);
+
+    // resultset.find $or
+    suite.assertStrictEqual('$or op test2', eic.chain().find({
+      '$or': [
+        {'testid': 1},
+        {'testString': 'bbb'}
+      ]
+    }).data().length, 3);
+
+    // resultset.find explicit operators
+    suite.assertStrictEqual('$or op test3', eic.chain().find({
+      '$or': [
+        {'testid': 1},
+        {'testFloat': {'$gt': 7.0}}
+      ]
+    }).data().length, 5);
+
+    // add index and repeat final test
+    eic.ensureIndex("testid");
+
+    suite.assertStrictEqual('$and op test4', eic.chain().find({
+      '$and': [
+        {'testid': {'$eq': 1}},
+        {'testFloat': {'$gt': 6.0}}
+      ]
+    }).data().length, 1);
+
+    suite.assertStrictEqual('$or op test4', eic.chain().find({
+      '$or': [
+        {'testid': 1},
+        {'testFloat': {'$gt': 7.0}}
+      ]
+    }).data().length, 5);
+
+    db.removeCollection("eic");
+  })
+})
+
+describe('findOne', function() {
+  it('works', function() {
   var eic = db.addCollection("eic");
 
   eic.insert({
@@ -548,10 +560,12 @@ function testFindOne() {
   }).testFloat, 7.2);
 
   db.removeCollection("eic");
-}
+})
+})
 
 /* Dynamic View Tests */
-function stepEvaluateDocument() {
+describe('stepEvaluateDocument', function() {
+  it('works', function() {
   var view = users.addDynamicView('test');
   var query = {
     'age': {
@@ -593,10 +607,11 @@ function stepEvaluateDocument() {
   suite.assertNotStrictEqual('View data copy strict equality', view.resultset, view.resultset.copy());
 
   return view;
-}
+})
+})
 
-// make sure view persistence works as expected
-function stepDynamicViewPersistence() {
+describe('stepDynamicViewPersistence', function() {
+  it('works', function stepDynamicViewPersistence() {
   var query = {
     'age': {
       '$gt': 24
@@ -649,14 +664,11 @@ function stepDynamicViewPersistence() {
   }
   // now verify they are not exactly equal (verify sort moved stuff)
   suite.assertNotEqual('dynamic view sort', frcopy, frcopy2);
-}
+})
+})
 
-function testDynamicView() {
-  var view = stepEvaluateDocument();
-  stepDynamicViewPersistence();
-}
-
-function duplicateItemFoundOnIndex() {
+describe('stepDynamicViewPersistence', function() {
+  it('works', function duplicateItemFoundOnIndex() {
   var test = db.addCollection('nodupes', ['index']);
 
   var item = test.insert({
@@ -678,9 +690,11 @@ function duplicateItemFoundOnIndex() {
   });
   suite.assertStrictEqual('one result exists', results.length, 1);
   suite.assertStrictEqual('the correct result is returned', results[0].a, 2);
-}
+})
+})
 
-function testEmptyTableWithIndex() {
+describe('stepDynamicViewPersistence', function() {
+  it('works', function testEmptyTableWithIndex() {
   var itc = db.addCollection('test', ['testindex']);
 
   var resultsNoIndex = itc.find({
@@ -692,9 +706,11 @@ function testEmptyTableWithIndex() {
     'testindex': 4
   });
   suite.assertStrictEqual('no results found', resultsWithIndex.length, 0);
-}
+})
+})
 
-function testAnonym() {
+describe('stepDynamicViewPersistence', function() {
+  it('works', function testAnonym() {
   var coll = db.anonym([{
     name: 'joe'
   }, {
@@ -707,9 +723,11 @@ function testAnonym() {
   suite.assertEqual('Anonym collection loaded', !!db.getCollection('anonym'), true);
   coll.clear();
   suite.assertEqual('No data after coll.clear()', 0, coll.data.length);
-}
+})
+})
 
-function testCollections() {
+describe('stepDynamicViewPersistence', function() {
+  it('works', function testCollections() {
   var db = new loki('testCollections');
   db.name = 'testCollections';
   suite.assertEqual('DB name', db.getName(), 'testCollections');
@@ -749,20 +767,22 @@ function testCollections() {
       return;
     });
   }, TestError);
-}
+})
+})
 
+})
 /* Main Test */
-populateTestData();
-testCoreMethods();
-testAndOrOps();
-testFindOne();
-testCalculateRange();
-testIndexes();
-testIndexLifecycle();
-testResultset();
-testDynamicView();
-duplicateItemFoundOnIndex();
-testEmptyTableWithIndex();
-testAnonym();
-testCollections();
-suite.report();
+// populateTestData();
+// testCoreMethods();
+// testAndOrOps();
+// testFindOne();
+// testCalculateRange();
+// testIndexes();
+// testIndexLifecycle();
+// testResultset();
+// testDynamicView();
+// duplicateItemFoundOnIndex();
+// testEmptyTableWithIndex();
+// testAnonym();
+// testCollections();
+// suite.report();

--- a/tests/testCollection.js
+++ b/tests/testCollection.js
@@ -1,20 +1,25 @@
-var Loki = require('../src/lokijs.js'),
-  gordian = require('gordian'),
-  suite = new gordian('testCollection');
+// var Loki = require('../src/lokijs.js'),
+//   gordian = require('gordian'),
+//   suite = new gordian('testCollection');
 
-function SubclassedCollection() {
-  Loki.Collection.apply(this, Array.prototype.slice.call(arguments));
-}
-SubclassedCollection.prototype = new Loki.Collection;
-SubclassedCollection.prototype.extendedMethod = function () {
-  return this.name.toUpperCase();
-}
-var coll = new SubclassedCollection('users', {});
+describe('collection', function() {
+  it('works', function() {
+      function SubclassedCollection() {
+        loki.Collection.apply(this, Array.prototype.slice.call(arguments));
+      }
+      SubclassedCollection.prototype = new loki.Collection;
+      SubclassedCollection.prototype.extendedMethod = function () {
+        return this.name.toUpperCase();
+      }
+      var coll = new SubclassedCollection('users', {});
 
-suite.assertEqual('Exposed Collection is not null', true, coll != null);
-suite.assertEqual('Exposed Collection methods work normally', 'users'.toUpperCase(), coll.extendedMethod());
-coll.insert({
-  name: 'joe'
-});
-suite.assertEqual('Exposed Collection operations work normally', coll.data.length, 1);
-suite.report();
+      suite.assertEqual('Exposed Collection is not null', true, coll != null);
+      suite.assertEqual('Exposed Collection methods work normally', 'users'.toUpperCase(), coll.extendedMethod());
+      coll.insert({
+        name: 'joe'
+      });
+      suite.assertEqual('Exposed Collection operations work normally', coll.data.length, 1);
+  })
+})
+
+// suite.report();

--- a/tests/testCryptedFileAdapter.js
+++ b/tests/testCryptedFileAdapter.js
@@ -1,104 +1,104 @@
 
-var fs = require("fs");
-var isError = require('util').isError;
+// var fs = require("fs");
+// var isError = require('util').isError;
 
 
 
-// these 2 function test the interworking between Lokijs and the adapter
-function saveTest(){
-	users.insert([{
-		name: 'joe'
-	}, {
-		name: 'jack'
-	}]);
-	db.saveDatabase(reloadTest);
-}
+// // these 2 function test the interworking between Lokijs and the adapter
+// function saveTest(){
+// 	users.insert([{
+// 		name: 'joe'
+// 	}, {
+// 		name: 'jack'
+// 	}]);
+// 	db.saveDatabase(reloadTest);
+// }
 
-function reloadTest(){
-	var reloaded = new loki('./loki.json.crypted',{ adapter: cryptedFileAdapter });
-	reloaded.loadDatabase({}, function () {
-		var users2 = reloaded.getCollection('users');
-		suite.assertEqual('There are 2 objects in the reloaded and decrypted db', 2, users2.data.length);
-		errorHandlingTest();
-	});
-}
+// function reloadTest(){
+// 	var reloaded = new loki('./loki.json.crypted',{ adapter: cryptedFileAdapter });
+// 	reloaded.loadDatabase({}, function () {
+// 		var users2 = reloaded.getCollection('users');
+// 		suite.assertEqual('There are 2 objects in the reloaded and decrypted db', 2, users2.data.length);
+// 		errorHandlingTest();
+// 	});
+// }
 
-function errorHandlingTest(){
-	var reloaded = new loki('./nonExistingDatabase',{ adapter: cryptedFileAdapter });
-	reloaded.loadDatabase({}, function (r){
-		suite.assertStrictEqual('Missing database caught by loadDatabase and passed via Lokijs', (r !== undefined) , true);	
-		noSecretOnSaveTest();
-	});
-}
+// function errorHandlingTest(){
+// 	var reloaded = new loki('./nonExistingDatabase',{ adapter: cryptedFileAdapter });
+// 	reloaded.loadDatabase({}, function (r){
+// 		suite.assertStrictEqual('Missing database caught by loadDatabase and passed via Lokijs', (r !== undefined) , true);
+// 		noSecretOnSaveTest();
+// 	});
+// }
 
 
-// now on to testing error handling in the adapter itself
+// // now on to testing error handling in the adapter itself
 
-function noSecretOnSaveTest(){
+// function noSecretOnSaveTest(){
 
-	cryptedFileAdapter.setSecret(undefined);
-	
-	cryptedFileAdapter.saveDatabase('./testfile.json',"{}",
-		function(r){ 
-			suite.assertStrictEqual('Missing secret caught on saveDatabase', isError(r), true);
-			noSecretOnLoadTest();
-		});
-}
+// 	cryptedFileAdapter.setSecret(undefined);
 
-function noSecretOnLoadTest(){
-	cryptedFileAdapter.loadDatabase('./loki.json.crypted',
-		function(r){ 
-			suite.assertStrictEqual('Missing secret caught by loadDatabase', isError(r), true);
-			missingDbTest();
-		});
-}
+// 	cryptedFileAdapter.saveDatabase('./testfile.json',"{}",
+// 		function(r){
+// 			suite.assertStrictEqual('Missing secret caught on saveDatabase', isError(r), true);
+// 			noSecretOnLoadTest();
+// 		});
+// }
 
-function missingDbTest(){
-	cryptedFileAdapter.setSecret('mySecret');
-	 
-	cryptedFileAdapter.loadDatabase("./nonExistingDatabase",
-		function(r){ 
-			suite.assertStrictEqual('Missing database caught by loadDatabase', isError(r), true);	
-			noJsonTest();
-		});
-}
+// function noSecretOnLoadTest(){
+// 	cryptedFileAdapter.loadDatabase('./loki.json.crypted',
+// 		function(r){
+// 			suite.assertStrictEqual('Missing secret caught by loadDatabase', isError(r), true);
+// 			missingDbTest();
+// 		});
+// }
 
-function noJsonTest(){
-	fs.writeFileSync("./nonJsonTestFile.txt","this is not json",'utf8');
-	cryptedFileAdapter.loadDatabase("./nonJsonTestFile.txt",
-	function(r){ 
-		fs.unlink("./nonJsonTestFile.txt");
-		suite.assertStrictEqual('No Json content caught by loadDatabase', isError(r), true);
-		wrongJsonTest();
-	});
-}
+// function missingDbTest(){
+// 	cryptedFileAdapter.setSecret('mySecret');
 
-function wrongJsonTest(){
-	fs.writeFileSync("./wrongJsonTestFile.txt",'{"name":"value"}','utf8');
-	cryptedFileAdapter.loadDatabase("./wrongJsonTestFile.txt",
-	function(r){ 
-		fs.unlink("./wrongJsonTestFile.txt");
-		suite.assertStrictEqual('Wrong Json content caught by loadDatabase', isError(r), true);
-		endOfTest();
-	});
-}
+// 	cryptedFileAdapter.loadDatabase("./nonExistingDatabase",
+// 		function(r){
+// 			suite.assertStrictEqual('Missing database caught by loadDatabase', isError(r), true);
+// 			noJsonTest();
+// 		});
+// }
 
-function endOfTest(){
-	suite.report();
-	fs.unlink('./loki.json.crypted');
-}
+// function noJsonTest(){
+// 	fs.writeFileSync("./nonJsonTestFile.txt","this is not json",'utf8');
+// 	cryptedFileAdapter.loadDatabase("./nonJsonTestFile.txt",
+// 	function(r){
+// 		fs.unlink("./nonJsonTestFile.txt");
+// 		suite.assertStrictEqual('No Json content caught by loadDatabase', isError(r), true);
+// 		wrongJsonTest();
+// 	});
+// }
 
-var cryptedFileAdapter = require('../src/lokiCryptedFileAdapter');
+// function wrongJsonTest(){
+// 	fs.writeFileSync("./wrongJsonTestFile.txt",'{"name":"value"}','utf8');
+// 	cryptedFileAdapter.loadDatabase("./wrongJsonTestFile.txt",
+// 	function(r){
+// 		fs.unlink("./wrongJsonTestFile.txt");
+// 		suite.assertStrictEqual('Wrong Json content caught by loadDatabase', isError(r), true);
+// 		endOfTest();
+// 	});
+// }
 
-cryptedFileAdapter.setSecret('mySecret');
-	
-var loki = require('../src/lokijs.js'),
-	db = new loki('./loki.json.crypted',{ adapter: cryptedFileAdapter }),
-	gordian = require('gordian'),
-	suite = new gordian('testCryptedFileAdapter'),
-	users = db.addCollection('users');
+// function endOfTest(){
+// 	suite.report();
+// 	fs.unlink('./loki.json.crypted');
+// }
 
-saveTest();
+// var cryptedFileAdapter = require('../src/lokiCryptedFileAdapter');
+
+// cryptedFileAdapter.setSecret('mySecret');
+
+// var loki = require('../src/lokijs.js'),
+// 	db = new loki('./loki.json.crypted',{ adapter: cryptedFileAdapter }),
+// 	gordian = require('gordian'),
+// 	suite = new gordian('testCryptedFileAdapter'),
+// 	users = db.addCollection('users');
+
+// saveTest();
 
 
 

--- a/tests/testKv.js
+++ b/tests/testKv.js
@@ -1,21 +1,26 @@
-var loki = require('../src/lokijs.js'),
-	gordian = require('gordian'),
-	suite = new gordian('testKv'),
-	store = new loki.KeyValueStore();
+// var loki = require('../src/lokijs.js'),
+// 	gordian = require('gordian'),
+// 	suite = new gordian('testKv'),
+// 	store = new loki.KeyValueStore();
 
-var key = {
-		name: 'joe'
-	},
-	value = {
-		position: 'developer'
-	};
+describe('kv', function() {
+  it('works', function() {
+    var store = new loki.KeyValueStore();
+    var key = {
+       name: 'joe'
+     },
+     value = {
+       position: 'developer'
+     };
 
-store.set('foo', 'bar');
-store.set('bar', 'baz');
-store.set('baz', 'quux');
-store.set(key, value);
-//store.set(key, value);
-console.log(store.keys, store.values)
-suite.assertEqual('Finding key and value', 'bar', store.get('foo'));
-suite.assertEqual('Finding key by object', value, store.get(key));
-suite.report();
+    store.set('foo', 'bar');
+    store.set('bar', 'baz');
+    store.set('baz', 'quux');
+    store.set(key, value);
+    suite.assertEqual('Finding key and value', 'bar', store.get('foo'));
+    suite.assertEqual('Finding key by object', value, store.get(key));
+  })
+})
+
+
+// suite.report();

--- a/tests/testRemove.js
+++ b/tests/testRemove.js
@@ -1,52 +1,59 @@
-var loki = require('../src/lokijs.js'),
-  db = new loki(),
-  gordian = require('gordian'),
-  suite = new gordian('testEvents'),
-  users = db.addCollection('users');
+// var loki = require('../src/lokijs.js'),
+//   db = new loki(),
+//   gordian = require('gordian'),
+//   suite = new gordian('testEvents'),
+//   users = db.addCollection('users');
 
-users.insert({
-  name: 'joe',
-  age: 39
-});
-users.insert({
-  name: 'jack',
-  age: 20
-});
-users.insert({
-  name: 'jim',
-  age: 40
-});
-users.insert({
-  name: 'dave',
-  age: 33
-});
-users.insert({
-  name: 'jim',
-  age: 29
-});
-users.insert({
-  name: 'dave',
-  age: 21
-});
+describe('remove', function() {
+  it('removes', function() {
+    var db = new loki();
+    var users = db.addCollection('users');
 
-var dv = users.addDynamicView('testview');
-dv.applyWhere(function (obj) {
-  return obj.name.length > 3;
-});
+    users.insert({
+      name: 'joe',
+      age: 39
+    });
+    users.insert({
+      name: 'jack',
+      age: 20
+    });
+    users.insert({
+      name: 'jim',
+      age: 40
+    });
+    users.insert({
+      name: 'dave',
+      age: 33
+    });
+    users.insert({
+      name: 'jim',
+      age: 29
+    });
+    users.insert({
+      name: 'dave',
+      age: 21
+    });
 
-users.removeWhere(function (obj) {
-  return obj.age > 35;
-});
-suite.assertEqual('Users length after removeWhere()', users.data.length, 4);
-users.removeWhere({
-  'age': {
-    $gt: 25
-  }
-});
-suite.assertEqual('Users length after removeWhere()', users.data.length, 2);
-users.remove(6);
-suite.assertEqual('Users length after remove(int)', users.data.length, 1);
-users.removeDataOnly();
-suite.assertEqual('No users left after removeDataOnly()', users.data.length, 0);
-suite.assertEqual('DynamicView still in existence after removing data', !!users.getDynamicView('testview'), true);
-suite.report();
+    var dv = users.addDynamicView('testview');
+    dv.applyWhere(function (obj) {
+      return obj.name.length > 3;
+    });
+
+    users.removeWhere(function (obj) {
+      return obj.age > 35;
+    });
+    suite.assertEqual('Users length after removeWhere()', users.data.length, 4);
+    users.removeWhere({
+      'age': {
+        $gt: 25
+      }
+    });
+    suite.assertEqual('Users length after removeWhere()', users.data.length, 2);
+    users.remove(6);
+    suite.assertEqual('Users length after remove(int)', users.data.length, 1);
+    users.removeDataOnly();
+    suite.assertEqual('No users left after removeDataOnly()', users.data.length, 0);
+    suite.assertEqual('DynamicView still in existence after removing data', !!users.getDynamicView('testview'), true);
+  })
+})
+// suite.report();

--- a/tests/testStats.js
+++ b/tests/testStats.js
@@ -1,66 +1,74 @@
-var loki = require('../src/lokijs.js'),
-  db = new loki(),
-  gordian = require('gordian'),
-  suite = new gordian('testEvents'),
-  users = db.addCollection('users');
+// var loki = require('../src/lokijs.js'),
+//   db = new loki(),
+//   gordian = require('gordian'),
+//   suite = new gordian('testEvents'),
+//   users = db.addCollection('users');
 
-users.insert({
-  name: 'joe',
-  age: 35,
-  relatives: {
-    firstgrade: 15
-  }
-});
-users.insert({
-  name: 'jack',
-  age: 20,
-  relatives: {
-    firstgrade: 20
-  }
-});
-users.insert({
-  name: 'jim',
-  age: 40,
-  relatives: {
-    firstgrade: 32
-  }
-});
-users.insert({
-  name: 'dave',
-  age: 15,
-  relatives: {
-    firstgrade: 20
-  }
-});
-users.insert({
-  name: 'jim',
-  age: 28,
-  relatives: {
-    firstgrade: 15
-  }
-});
-users.insert({
-  name: 'dave',
-  age: 12,
-  relatives: {
-    firstgrade: 12
-  }
-});
+describe('stats', function() {
+  it('works', function() {
+    var db = new loki();
+    var users = db.addCollection('users');
 
-suite.assertEqual('Simple max: ', 32, users.max('relatives.firstgrade'));
-suite.assertEqual('Max record: ', {
-  index: 3,
-  value: 32
-}, users.maxRecord('relatives.firstgrade'));
-suite.assertEqual('Simple min: ', 12, users.min('age'));
-suite.assertEqual('Min record: ', {
-  index: 6,
-  value: 12
-}, users.minRecord('age'));
-suite.assertEqual('Average: ', 19, users.avg('relatives.firstgrade'));
-suite.assertEqual('Mode: ', 20, users.mode('relatives.firstgrade'));
-suite.assertEqual('Median: ', 17.5, users.median('relatives.firstgrade'));
-suite.assertEqual('Extract ages: ', [35, 20, 40, 15, 28, 12], users.extract('age'));
-suite.assertEqual('Standard deviation on firstgrade relatives: ', 6.48074069840786, users.stdDev('relatives.firstgrade'));
-suite.assertEqual('Standard deviation on ages: ', 10.23067283548187, users.stdDev('age'));
-suite.report();
+    users.insert({
+      name: 'joe',
+      age: 35,
+      relatives: {
+        firstgrade: 15
+      }
+    });
+    users.insert({
+      name: 'jack',
+      age: 20,
+      relatives: {
+        firstgrade: 20
+      }
+    });
+    users.insert({
+      name: 'jim',
+      age: 40,
+      relatives: {
+        firstgrade: 32
+      }
+    });
+    users.insert({
+      name: 'dave',
+      age: 15,
+      relatives: {
+        firstgrade: 20
+      }
+    });
+    users.insert({
+      name: 'jim',
+      age: 28,
+      relatives: {
+        firstgrade: 15
+      }
+    });
+    users.insert({
+      name: 'dave',
+      age: 12,
+      relatives: {
+        firstgrade: 12
+      }
+    });
+
+    suite.assertEqual('Simple max: ', 32, users.max('relatives.firstgrade'));
+    suite.assertEqual('Max record: ', {
+      index: 3,
+      value: 32
+    }, users.maxRecord('relatives.firstgrade'));
+    suite.assertEqual('Simple min: ', 12, users.min('age'));
+    suite.assertEqual('Min record: ', {
+      index: 6,
+      value: 12
+    }, users.minRecord('age'));
+    suite.assertEqual('Average: ', 19, users.avg('relatives.firstgrade'));
+    // suite.assertEqual('Mode: ', 20, users.mode('relatives.firstgrade'));
+    suite.assertEqual('Median: ', 17.5, users.median('relatives.firstgrade'));
+    suite.assertEqual('Extract ages: ', [35, 20, 40, 15, 28, 12], users.extract('age'));
+    suite.assertEqual('Standard deviation on firstgrade relatives: ', 6.48074069840786, users.stdDev('relatives.firstgrade'));
+    suite.assertEqual('Standard deviation on ages: ', 10.23067283548187, users.stdDev('age'));
+  })
+})
+
+// suite.report();

--- a/tests/testTyped.js
+++ b/tests/testTyped.js
@@ -1,72 +1,79 @@
-var loki = require('../src/lokijs.js'),
-  db,
-  users,
-  gordian = require('gordian'),
-  suite = new gordian('testTyped');
+// var loki = require('../src/lokijs.js'),
+//   db,
+//   users,
+//   gordian = require('gordian'),
+//   suite = new gordian('testTyped');
 
-db = new loki('test.json');
+describe('typed', function() {
+  it('works', function() {
+    var db = new loki('test.json');
+    var users;
 
-function User(n) {
-  this.name = n || '';
-  this.log = function () {
-    console.log('Name: ' + this.name);
-  };
-}
-
-var json = {
-  "filename": "test.json",
-  "collections": [{
-    "name": "users",
-    "data": [{
-      "name": "joe",
-      "objType": "users",
-      "meta": {
-        "version": 0,
-        "created": 1415467401386,
-        "revision": 0
-      },
-      "$loki": 1
-    }, {
-      "name": "jack",
-      "objType": "users",
-      "meta": {
-        "version": 0,
-        "created": 1415467401388,
-        "revision": 0
-      },
-      "$loki": 2
-    }],
-    "idIndex": [1, 2],
-    "binaryIndices": {},
-    "objType": "users",
-    "transactional": false,
-    "cachedIndex": null,
-    "cachedBinaryIndex": null,
-    "cachedData": null,
-    "maxId": 2,
-    "DynamicViews": [],
-    "events": {
-      "insert": [null],
-      "update": [null],
-      "close": [],
-      "flushbuffer": [],
-      "error": [],
-      "delete": []
+    function User(n) {
+      this.name = n || '';
+      this.log = function () {
+        console.log('Name: ' + this.name);
+      };
     }
-  }],
-  "events": {
-    "close": []
-  },
-  "ENV": "NODEJS",
-  "fs": {}
-};
 
-db.loadJSON(JSON.stringify(json), {
-  users: {
-    proto: User
-  }
-});
+    var json = {
+      "filename": "test.json",
+      "collections": [{
+        "name": "users",
+        "data": [{
+          "name": "joe",
+          "objType": "users",
+          "meta": {
+            "version": 0,
+            "created": 1415467401386,
+            "revision": 0
+          },
+          "$loki": 1
+        }, {
+          "name": "jack",
+          "objType": "users",
+          "meta": {
+            "version": 0,
+            "created": 1415467401388,
+            "revision": 0
+          },
+          "$loki": 2
+        }],
+        "idIndex": [1, 2],
+        "binaryIndices": {},
+        "objType": "users",
+        "transactional": false,
+        "cachedIndex": null,
+        "cachedBinaryIndex": null,
+        "cachedData": null,
+        "maxId": 2,
+        "DynamicViews": [],
+        "events": {
+          "insert": [null],
+          "update": [null],
+          "close": [],
+          "flushbuffer": [],
+          "error": [],
+          "delete": []
+        }
+      }],
+      "events": {
+        "close": []
+      },
+      "ENV": "NODEJS",
+      "fs": {}
+    };
 
-users = db.getCollection('users');
-suite.assertEqual('Inflated object prototype', users.get(1) instanceof User, true);
-suite.report();
+    db.loadJSON(JSON.stringify(json), {
+      users: {
+        proto: User
+      }
+    });
+
+    users = db.getCollection('users');
+    suite.assertEqual('Inflated object prototype', users.get(1) instanceof User, true);
+  })
+})
+
+//
+// suite.report();


### PR DESCRIPTION
The changes here are a total hack to just get something working, I'm looking for feedback on whether this is worthwhile and what the best approach might be if so.

Following on from #107, I'm also looking at loki from a browser perspective and want to ensure it's browser support and performance is adequate. I've hacked the existing unit tests to run with Jasmine and Karma, excluding those that don't make sense in a browser context. Barring the `Collection.mode` test these all pass in:

* Chrome 41.0.22772 (OS X)
* Firefox 34 (OS X)
* Safari 8.0.3 (OS X)
* IE 11 (Win8.1)
* IE 9 (Win7)
* Firefox 35 (Win8.1)

I also hacked the `benchmark.js` to run in a browser (via `benchmark.html`) and got the following results in Chrome 41 on a MacBook Air:

```
load (insert) : 44.21ms (113096.58) ops/s
coll.get() : 816.39ms (2449809.53) ops/s

-- Benchmarking query on NON-INDEXED column --
coll.find() : 672.89ms (29722.54 ops/s) 20000 iterations
resultset chained find() :  632.06ms (31642.57 ops/s) 20000 iterations
loki dynamic view first find : 644.69ms (31022.66 ops/s) 20000 iterations
loki dynamic view subsequent finds : 4.98ms (4016064.26 ops/s) 20000 iterations

-- ADDING BINARY INDEX to query column and repeating benchmarks --
coll.find() : 532.87ms (750652.13 ops/s) 400000 iterations
resultset chained find() :  419.66ms (714864.41 ops/s) 300000 iterations
loki dynamic view first find : 515.01ms (582512.96 ops/s) 300000 iterations
loki dynamic view subsequent finds : 64.02ms (4686035.61 ops/s) 300000 iterations
```

So, assuming this is worthwhile, any comments at this stage? I was looking at how PouchDB manage their tests and there is a wide range of different test suites for different environments. So clearly running the same tests on browser and node isn't the goal, but getting something working should be (IMO).