### PR TITLE
add publish to package.json

### DIFF
--- a/karma.build.conf.js
+++ b/karma.build.conf.js
@@ -1,0 +1,73 @@
+// Karma configuration
+// Generated on Wed Mar 25 2015 21:28:22 GMT+0000 (GMT)
+
+module.exports = function (config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'build/lokijs.min.js',
+      'spec/helpers/assert-helpers.js',
+      'spec/generic/*.js',
+      'spec/browser/*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      // source files, that you wanna generate coverage for
+      // do not include tests or libraries
+      // (these files will be instrumented by Istanbul)
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    // coverage reporter generates the coverage
+    reporters: ['dots'],
+
+    
+    // web server port
+    port: 9876,
+
+    hostname: '0.0.0.0',
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/package.json
+++ b/package.json
@@ -24,11 +24,16 @@
     "lint": "jshint src/**.js",
     "test:browser": "karma start karma.conf.js --single-run",
     "test:node": "istanbul cover --dir coverage/nodejs jasmine",
+    "todo-pretest" : "npm run lint",
     "test": "npm run test:browser && npm run test:node",
     "build:lokijs": "uglifyjs src/lokijs.js > build/lokijs.min.js",
     "build:indexedAdapter": "uglifyjs src/lokiIndexedAdapter.js > build/lokiIndexedAdapter.min.js",
     "build": "npm run build:lokijs && npm run build:indexedAdapter",
-    "clean": "rimraf build/* coverage/* node_modules"
+    "postbuild": "karma start karma.build.conf.js --single-run",
+    "prepublish": "npm run build",
+    "publish": "npm version patch && npm publish && npm run pour:beer",
+    "clean": "rimraf build/* coverage/* node_modules",
+    "pour:beer": "echo New npm version published, one beer for you !"
   },
   "author": "Joe Minichino <joe.minichino@gmail.com>",
   "contributors": [{


### PR DESCRIPTION
As requested:

Package.json now holds a few extra script lines, most importantly publish
Invoke it using 'npm run publish', if all goes well it will:
bump the npm version, do a git tag (built-in feature of npm version) and pour you a beer ;-)

Publish will only work on an clean git working directory, so all work in progress must have been committed before.

I can't fully test publish myself as I don't have access to the npm publish command, so you'll have to try this yourself next time when you publish (on paper it should work)

I have used a second karma config, as a coverage test on a minified js is not really meaningful and I did not have another way to tell karma to skip the coverage test.

Still todo is the activition of lint as a pretest condition.
Reason for this is that the current Lokijs does not pass jshint due to redefinition of variables.
There are a few ways to fix this:
- rename i to i1, i2 etc
- rename i to j,k,l etc
- isolate these parts in separate functions to restrict scope 

Happy to fix this as well if you indicate your preference.


