### PR TITLE
Safari IndexedDBAdapter Issue

### DIFF
--- a/src/loki-indexed-adapter.js
+++ b/src/loki-indexed-adapter.js
@@ -349,7 +349,7 @@ var lokiIndexedAdapter = (function() {
       return function(e) {
         var lres = e.target.result;
 
-        if (typeof(lres) === 'undefined') {
+        if (lres === null || typeof(lres) === 'undefined') {
           lres = { 
             id: 0, 
             success: false 


### PR DESCRIPTION
The first time you save using indexedAdapter in Safari. you get the following error "TypeError: null is not an object [evaluating 'result.id']".  This is because Safari returns a null result if an index is not found not undefined like Chrome.  I fixed the code to check for both null or undefined.