### PR TITLE
Add commonjs require to loki-indexed-adapter.js

### DIFF
--- a/src/loki-indexed-adapter.js
+++ b/src/loki-indexed-adapter.js
@@ -566,5 +566,9 @@ var lokiIndexedAdapter = (function() {
 
   };
 
+  if(module && module.exports) {
+    module.exports = IndexedAdapter; 
+  }
+
   return IndexedAdapter;
 }());


### PR DESCRIPTION
Hi there!

I wanted to include the indexedb lokijs adapter in my gulp browserify build, but it misses a module.exports. Adding this to the bottom allows browserify builds without shimming and shouldn't break regular script includes. Let me know if it needs some more work! 