### PR TITLE
Fix reference to global loki variable

### DIFF
--- a/src/loki-angular.js
+++ b/src/loki-angular.js
@@ -23,7 +23,7 @@
 } (this, function (angular, lokijs) {
 	var module = angular.module('lokijs', [])
 		.factory('Loki', function Loki() {
-			return lokijs;
+			return loki;
 		});
 	return module;
 }));


### PR DESCRIPTION
The global loki variable name changed from lokijs to loki thus breaking the angular module.