### PR TITLE
Fix issue #187

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -3083,13 +3083,14 @@
         obj.$loki = this.maxId;
         obj.meta.version = 0;
 
-        // add the object
-        this.data.push(obj);
-
         var self = this;
         Object.keys(this.constraints.unique).forEach(function (key) {
+          // Function set will throw error when unique constraint is not honoured
           self.constraints.unique[key].set(obj);
         });
+
+        // add the object
+        this.data.push(obj);
 
         // now that we can efficiently determine the data[] position of newly added document,
         // submit it for all registered DynamicViews to evaluate for inclusion/exclusion


### PR DESCRIPTION
**(1) This is the problematic code**
        3098     // add the object
        3099     this.data.push(obj);
        3100
        3101     var self = this;
        3102     Object.keys(this.constraints.unique).forEach(function (key) {
        3103       self.constraints.unique[key].set(obj);                                        <= error thrown here
        3104     });

**(2) This is the working code**
        3098     var self = this;
        3099     Object.keys(this.constraints.unique).forEach(function (key) {
        3100       self.constraints.unique[key].set(obj);                                        <= error thrown here
        3101     });
        3102     
        3103     // add the object
        3104     this.data.push(obj);

This is because as @tnarik mentioned, it print to console the following "warning" which is in fact an error thrown.
>Duplicate key for property...

In (1), the object has already been added to the collection then only the error is thrown (under set function) - thus, having (2) will solve the problem of "Insert although same unique field"