### PR TITLE
Update loadJSON to avoid Unexpected enf of input

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -617,6 +617,7 @@
      */
     Loki.prototype.loadJSON = function (serializedDb, options) {
 
+      if(serializedDb.length===0) serializedDb=JSON.stringify({});
       var obj = JSON.parse(serializedDb),
         i = 0,
         len = obj.collections ? obj.collections.length : 0,


### PR DESCRIPTION
In some cases (Error from our node), the database file got erased, only a blank file remains. 
So loadJSON serialize from an empty file throwing this SyntaxError.