### PR TITLE
Fix minor bug in autoupdate implementation

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -2879,7 +2879,7 @@
 
         if(!changedObjects.add)
           changedObjects.add = function(object) {
-            if(this.indexOf(object) !== -1)
+            if(this.indexOf(object) === -1)
               this.push(object);
             return this;
           };


### PR DESCRIPTION
I just noticed, that I got the Set fallback implementation wrong.

Nothing severe, since only Chrome 36 + 37 supports Object.observe and does not offer Set.