### PR TITLE
Correct a misprint in DynamicView.prototype.applySortCriteria

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -2398,7 +2398,7 @@
      * @returns {DynamicView} Reference to this DynamicView, sorted, for future chain operations.
      */
     DynamicView.prototype.applySortCriteria = function (criteria) {
-      this.sortCriterial = criteria;
+      this.sortCriteria = criteria;
       this.sortFunction = null;
 
       this.queueSortPhase();


### PR DESCRIPTION
Currently, due to an existing misprint in the property name, the criteria passed as a parameter to the function is not used for the actual sorting.