### PR TITLE
 Ensure that the data returned by ResultSet never expose a ref. the original collection data

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -1681,7 +1681,7 @@
         }
         // not chained, so return collection data array
         else {
-          return this.collection.data;
+          return this.collection.data.slice();
         }
       }
 
@@ -2029,7 +2029,7 @@
       // if this is chained resultset with no filters applied, just return collection.data
       if (this.searchIsChained && !this.filterInitialized) {
         if (this.filteredrows.length === 0) {
-          return this.collection.data;
+          return this.collection.data.slice();
         } else {
           // filteredrows must have been set manually, so use it
           this.filterInitialized = true;
@@ -3441,9 +3441,7 @@
     };
 
     Collection.prototype.removeDataOnly = function () {
-      this.removeWhere(function (obj) {
-        return true;
-      });
+      this.remove(this.data.slice());
     };
 
     /**


### PR DESCRIPTION
In the current implementation, when the "persistent" option is configured for a dynamic view, the `evaluateDocument(...)` and `removeDocument(...)` methods of the view modify its `resultdata` to keep them consistent with the changes in the original collection data (after applying the configured filtering, if any).

In the case when there is no actual filter applied to the view, the `resultset.data()` method simply returns a reference to the actual data owned and controlled by the linked collection. (Doing so _is_ actually good for performance, thus I do not think we would need to change that aspect.) Unfortunately, in this case, the current implementation of the dynamic view simply keeps modifying "its" persistent data – in reality, it is making changes to the actual collection data. That causes some very subtle issues and "strange" errors when using dynamic views without a filter (with or without a sort parameter).

The suggested fix ensures that any modifications to a dynamic view's persistent data are only done on a copy of the collection data, fully owned and controlled by that dynamic view. Never on the original collection data.