### PR TITLE
Quick fix to method removeTransform() of Collection

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -3076,7 +3076,7 @@
     };
 
     Collection.prototype.removeTransform = function (name) {
-      delete transforms[name];
+      delete this.transforms[name];
     };
 
     Collection.prototype.byExample = function (template) {


### PR DESCRIPTION
Just another quick correction upon noticing a missing reference to `this` in the code.