### PR TITLE
Pass the proper view reference when emitting the 'rebuild' event in queueRebuildEvent

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -2745,7 +2745,7 @@
 
       setTimeout(function () {
         self.rebuildPending = false;
-        self.emit('rebuild', this);
+        self.emit('rebuild', self);
       }, 1);
     };
 


### PR DESCRIPTION
Currently the callback function inside `setTimeout()` passes local `this` instead of using `self`.