### PR TITLE
Fix the result of find('getAll') for ResultSet with an initialized filter

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -1727,8 +1727,10 @@
         // chained queries can just do coll.chain().data() but let's
         // be versatile and allow this also coll.chain().find().data()
         if (this.searchIsChained) {
-          this.filteredrows = Object.keys(this.collection.data).map(Number);
-          this.filterInitialized = true;
+          if (!this.filterInitialized && this.filteredrows.length === 0) {
+            this.filteredrows = Object.keys(this.collection.data).map(Number);
+            this.filterInitialized = true;
+          }
           return this;
         }
         // not chained, so return collection data array


### PR DESCRIPTION
Fixing a long outstanding bug in `ResultSet`'s method `find` when it is called with no argument or with 'getAll' in the case where the result-set *does* already have its filter initialized. That was the major reason of the super-slow behavior that Loki showed in my recent tests with big data sets (when some dynamic views were applied on top of them so that a dynamic view had no real filters applied to the data): In the `DynamicView`'s `evaluateDocument` method that would cause re-creating the whole index range of the collection's data upon applying the "fake" find-filter (= 'getAll') to `evalResultset`. In the case of datasets above 5-10K records, it is not difficult to see how that affected each insert operation.

Note for @obeliskos: That was the actual reason of the speed difference that I mentioned in latest private e-mail to you. With this fix, the things are way better now. Having said that, I still believe that the initial code in the `data` method of `DynamicView` is unnecessary. (Looking forward to your reply on that matter.)