### PR TITLE
Refactoring the logic of performSortPhase() a little bit

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -2798,24 +2798,21 @@
         return;
       }
 
-      if (this.sortFunction) {
-        this.resultset.sort(this.sortFunction);
-      }
-
-      if (this.sortCriteria) {
-        this.resultset.compoundsort(this.sortCriteria);
-      }
-
-      if (!this.options.persistent) {
+      if (this.sortDirty) {
+        if (this.sortFunction) {
+          this.resultset.sort(this.sortFunction);
+        } else if (this.sortCriteria) {
+          this.resultset.compoundsort(this.sortCriteria);
+        }
+        
         this.sortDirty = false;
-        this.emit('rebuild', this);
-        return;
       }
 
-      // persistent view, rebuild local resultdata array
-      this.resultdata = this.resultset.data();
-      this.resultsdirty = false;
-      this.sortDirty = false;
+      if (this.options.persistent) {
+        // persistent view, rebuild local resultdata array
+        this.resultdata = this.resultset.data();
+        this.resultsdirty = false;
+      }
 
       this.emit('rebuild', this);
     };


### PR DESCRIPTION
A small change to the original logic of `performSortPhase()`, to make its flow more straightforward and (*hopefully*) more predictable with any combination of `sortDirty` and `resultsdirty` flags.

@obeliskos, please, let me know if you have any concerns around the changes proposed.