### PR TITLE
Enhancing Loki with new operators '$keyin' and '$nkeyin'

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -206,11 +206,19 @@
       },
 
       $in: function (a, b) {
-        return b.indexOf(a) > -1;
+        return b.indexOf(a) !== -1;
       },
 
       $nin: function (a, b) {
-        return b.indexOf(a) == -1;
+        return b.indexOf(a) === -1;
+      },
+
+      $keyin: function (a, b) {
+        return b[a] !== undefined;
+      },
+
+      $nkeyin: function (a, b) {
+        return b[a] === undefined;
       },
 
       $containsNone: function (a, b) {
@@ -270,6 +278,8 @@
       '$regex': LokiOps.$regex,
       '$in': LokiOps.$in,
       '$nin': LokiOps.$nin,
+      '$keyin': LokiOps.$keyin,
+      '$nkeyin': LokiOps.$nkeyin,
       '$contains': LokiOps.$contains,
       '$containsAny': LokiOps.$containsAny,
       '$containsNone': LokiOps.$containsNone


### PR DESCRIPTION
I did not see those operators in MongoDB's query "language". I just did found them very useful in my own practice, as an alternative to '$in' and '$nin' when a bigger set of string values need to be used in the query. Checking if a key exists (and is not equal to `undefined`) in the JS-object is notably more efficient than a repetitive execution of `indexOf()` over a set of values contained in the array (except for very-very small arrays).

*Note: I also made a small change to the comparison JS-operators used for the `$in` and `$nin` Loki-operators to use strict comparisons. For the 'number' type that tends to be a tiny little bit more efficient in modern browsers. (If any concerns on that, let me know.)*