### PR TITLE
Safe check for window variable

### DIFF
--- a/src/loki-indexed-adapter.js
+++ b/src/loki-indexed-adapter.js
@@ -86,7 +86,7 @@
      */
     IndexedAdapter.prototype.checkAvailability = function()
     {
-      if (window && window.indexedDB) return true;
+      if (typeof window !== 'undefined' && window.indexedDB) return true;
 
       return false;
     };


### PR DESCRIPTION
When building isomorphic apps, node process crashes as `window` is not defined. Using `typeof window !== 'undefined'` solves the issue.