### PR TITLE
Call loadDatabase callback with parsing error

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -971,9 +971,17 @@
 
         this.persistenceAdapter.loadDatabase(this.filename, function loadDatabaseCallback(dbString) {
           if (typeof (dbString) === 'string') {
-            self.loadJSON(dbString, options || {});
-            cFun(null);
-            self.emit('loaded', 'database ' + self.filename + ' loaded');
+            var parseSuccess = false;
+            try {
+              self.loadJSON(dbString, options || {});
+              parseSuccess = true;
+            } catch (err) {
+              cFun(err);
+            }
+            if (parseSuccess) {
+              cFun(null);
+              self.emit('loaded', 'database ' + self.filename + ' loaded');
+            }
           } else {
             if (typeof (dbString) === "object") {
               cFun(dbString);


### PR DESCRIPTION
When the database's JSON cannot be parsed back, we have to call the
callback function with the error.  This is important as the
loadDatabaseCallback can be called asynchronously, and in that case, we
have no means to intercept the error if cFun is not called.

With this fix, the error can be handled in the callback function that is
passed to Loki.loadDatabase().