### PR TITLE
Make removeCollection work (fixes #348)

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -756,6 +756,13 @@
 
       for (i = 0; i < len; i += 1) {
         if (this.collections[i].name === collectionName) {
+          var tmpcol = new Collection(collectionName, {});
+          var curcol = this.collections[i];
+          for (var prop in curcol) {
+            if (curcol.hasOwnProperty(prop) && tmpcol.hasOwnProperty(prop)) {
+                curcol[prop] = tmpcol[prop];
+            }
+          }
           this.collections.splice(i, 1);
           return;
         }


### PR DESCRIPTION
The reference count isn't decreased just by slicing the collection itself from the collections array. For the reference counter to actually be decreased (and make the GC kick in), each property of the collection we're trying to remove must be null-ified.

An easy way would be to just do

```
this.collections[i].data = null;
this.collections[i].binaryIndices = null;
this.collections[i].flushbuffer = null;
...etc...
```

but by creating a new collection we know that even if a new property of the `Collection` class is added in the future, we'll be safe and we'll remove it (as we're iterating all the proper keys of the class itself).