### PR TITLE
Fix #344

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -75,7 +75,7 @@
     // Sort helper that support null and undefined
     function ltHelper(prop1, prop2, equal) {
 
-      if (typeof(prop1) === "boolean" && typeof(prop2) === "boolean") {
+      if ((prop1 === true || prop1 === false) && (prop2 === true || prop2 === false)) {
         if (equal) {
           return prop1 === prop2;
         } else {
@@ -108,7 +108,7 @@
 
     function gtHelper(prop1, prop2, equal) {
 
-      if (typeof(prop1) === "boolean" && typeof(prop2) === "boolean") {
+      if ((prop1 === true || prop1 === false) && (prop2 === true || prop2 === false)) {
         if (equal) {
           return prop1 === prop2;
         } else {

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -95,6 +95,17 @@
         if (prop2 === undefined || prop2 === null || prop1 === true || prop2 === false) {
           return false;
         }
+
+        if (prop1 < prop2) {
+          return true;
+        }
+
+        if (prop1 > prop2) {
+          return false;
+        }
+
+        // not lt and and not gt so equality assumed-- this ordering of tests is date compatible
+        return equal;
       }
 
       if (prop1 < prop2) {
@@ -131,6 +142,17 @@
         if (prop2 === undefined || prop2 === null || prop1 === true || prop2 === false) {
           return true;
         }
+
+        if (prop1 > prop2) {
+          return true;
+        }
+
+        if (prop1 < prop2) {
+          return false;
+        }
+
+        // not lt and and not gt so equality assumed-- this ordering of tests is date compatible
+        return equal;
       }
 
       if (prop1 > prop2) {

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -75,23 +75,26 @@
     // Sort helper that support null and undefined
     function ltHelper(prop1, prop2, equal) {
 
-      if ((prop1 === true || prop1 === false) && (prop2 === true || prop2 === false)) {
-        if (equal) {
-          return prop1 === prop2;
-        } else {
-          if (prop1) {
-            return false;
+      // 'falsy' and Boolean handling
+      if (!prop1 || !prop2 || prop1 === true || prop2 === true) {
+        if ((prop1 === true || prop1 === false) && (prop2 === true || prop2 === false)) {
+          if (equal) {
+            return prop1 === prop2;
           } else {
-            return prop2;
+            if (prop1) {
+              return false;
+            } else {
+              return prop2;
+            }
           }
         }
-      }
 
-      if (prop1 === undefined || prop1 === null || prop1 === false || prop2 === true) {
-        return true;
-      }
-      if (prop2 === undefined || prop2 === null || prop1 === true || prop2 === false) {
-        return false;
+        if (prop1 === undefined || prop1 === null || prop1 === false || prop2 === true) {
+          return true;
+        }
+        if (prop2 === undefined || prop2 === null || prop1 === true || prop2 === false) {
+          return false;
+        }
       }
 
       if (prop1 < prop2) {

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -74,6 +74,19 @@
 
     // Sort helper that support null and undefined
     function ltHelper(prop1, prop2, equal) {
+
+      if (typeof(prop1) === "boolean" && typeof(prop2) === "boolean") {
+        if (equal) {
+          return prop1 === prop2;
+        } else {
+          if (prop1) {
+            return false;
+          } else {
+            return prop2;
+          }
+        }
+      }
+
       if (prop1 === undefined || prop1 === null || prop1 === false || prop2 === true) {
         return true;
       }
@@ -94,6 +107,19 @@
     }
 
     function gtHelper(prop1, prop2, equal) {
+
+      if (typeof(prop1) === "boolean" && typeof(prop2) === "boolean") {
+        if (equal) {
+          return prop1 === prop2;
+        } else {
+          if (prop1) {
+            return !prop2;
+          } else {
+            return false;
+          }
+        }
+      }
+
       if (prop1 === undefined || prop1 === null || prop1 === false || prop2 === true) {
         return false;
       }

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -108,23 +108,26 @@
 
     function gtHelper(prop1, prop2, equal) {
 
-      if ((prop1 === true || prop1 === false) && (prop2 === true || prop2 === false)) {
-        if (equal) {
-          return prop1 === prop2;
-        } else {
-          if (prop1) {
-            return !prop2;
+      // 'falsy' and Boolean handling
+      if (!prop1 || !prop2 || prop1 === true || prop2 === true) {
+        if ((prop1 === true || prop1 === false) && (prop2 === true || prop2 === false)) {
+          if (equal) {
+            return prop1 === prop2;
           } else {
-            return false;
+            if (prop1) {
+              return !prop2;
+            } else {
+              return false;
+            }
           }
         }
-      }
 
-      if (prop1 === undefined || prop1 === null || prop1 === false || prop2 === true) {
-        return false;
-      }
-      if (prop2 === undefined || prop2 === null || prop1 === true || prop2 === false) {
-        return true;
+        if (prop1 === undefined || prop1 === null || prop1 === false || prop2 === true) {
+          return false;
+        }
+        if (prop2 === undefined || prop2 === null || prop1 === true || prop2 === false) {
+          return true;
+        }
       }
 
       if (prop1 > prop2) {


### PR DESCRIPTION
This commit fixes bug #344 .
The bug happened at 2d21fcc9f683c1089522a1781318a045321fb617 . The problem with that commit is that it didn't had in mind that the props can be actually of a boolean type, which led to very awkward situations in which `ltHelper` would say that `true` is smaller than `false` (which is not true).

This patch fixes this behavior by checking the type of both props, and if both props are `boolean`, then it compares them with the following logic:

| prop1 | prop2 | ltHelper | gtHelper |
|---------|----------|------------|-------------|
| true   | true     | false      | false       |
| true   | false    |  false     | true        |
| false | true      | true       | false       |
| false | false    | false      | false       |

The code could be further shortened, but I leaved it as is on purpose. Reading it at it's current state doesn't require too much thinking, but shortening it further will require further time to read/debug and it won't bring any performance improvements at all.

@obeliskos Are you fine with this patch? (I'm asking because `git bisect` told me you introduced the changes in 2d21fcc9f683c1089522a1781318a045321fb617)