### PR TITLE
Node v5.10.0 update, specified digest

### DIFF
--- a/src/loki-crypted-file-adapter.js
+++ b/src/loki-crypted-file-adapter.js
@@ -47,7 +47,7 @@ function encrypt(input, secret) {
 
   try {
 
-    var key = cryptoLib.pbkdf2Sync(secret, salt, ITERATIONS, KEY_LENGTH / 8),
+    var key = cryptoLib.pbkdf2Sync(secret, salt, ITERATIONS, KEY_LENGTH / 8, 'sha1'),
       cipher = cryptoLib.createCipheriv(CIPHER, key, iv);
 
     var encryptedValue = cipher.update(input, 'utf8', 'base64');
@@ -104,7 +104,7 @@ function decrypt(input, secret) {
 
   try {
 
-    var key = cryptoLib.pbkdf2Sync(secret, salt, iterations, keyLength / 8),
+    var key = cryptoLib.pbkdf2Sync(secret, salt, iterations, keyLength / 8, 'sha1'),
       decipher = cryptoLib.createDecipheriv(CIPHER, key, iv);
 
     var decryptedValue = decipher.update(input.value, 'base64', 'utf8');


### PR DESCRIPTION
crypto.pbkdf2 without specifying a digest is deprecated. (Node v5.10.0)
If digest is not specified, default of sha1 is used on earlier Node versions. So, i didn't want to break anyone's app and set digest as sha1.

The error it gave on v5.10.0 was:
`DeprecationWarning: crypto.pbkdf2 without specifying a digest is deprecated`