### PR TITLE
Added automatic support for nativescript framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 LokiJS is a document oriented database written in javascript, published under MIT License.
 Its purpose is to store javascript objects as documents in a nosql fashion and retrieve them with a similar mechanism.
-Runs in node (including cordova/phonegap and node-webkit) and the browser.
+Runs in node (including cordova/phonegap and node-webkit),  [nativescript](http://www.nativescript.org) and the browser.
 LokiJS is ideal for the following scenarios: 
 
 1. client-side in-memory db is ideal (e.g., a session store)
@@ -17,6 +17,7 @@ LokiJS is ideal for the following scenarios:
 3. cordova/phonegap mobile apps where you can leverage the power of javascript and avoid interacting with native databases
 4. data sets loaded into a browser page and synchronised at the end of the work session
 5. node-webkit desktop apps
+6. nativescript mobile apps that mix the power and ubiquity of javascript with native performance and ui
 
 LokiJS supports indexing and views and achieves high-performance through maintaining unique and binary indexes (indices) for data.
 
@@ -32,7 +33,7 @@ Example usage can be found on the [wiki](https://github.com/techfort/LokiJS/wiki
 ### Main Features
 
 1. Fast performance NoSQL in-memory database, collections with unique index (1.1M ops/s) and binary-index (500k ops/s)
-2. Runs in multiple environments (browser, node)
+2. Runs in multiple environments (browser, node, nativescript)
 3. Dynamic Views for fast access of data subsets
 4. Built-in persistence adapters, and the ability to support user-defined ones
 5. Changes API
@@ -41,7 +42,7 @@ Example usage can be found on the [wiki](https://github.com/techfort/LokiJS/wiki
 ## Current state
 
 LokiJS is at version 1.3 [Eostre].
-As LokiJS is written in Javascript it can be run on any environment supporting javascript such as browsers, node.js/node-webkit, and hybrid mobile apps (such as phonegap/cordova).
+As LokiJS is written in Javascript it can be run on any environment supporting javascript such as browsers, node.js/node-webkit, nativescript mobile framework and hybrid mobile apps (such as phonegap/cordova).
 
 Made by [@techfort](http://twitter.com/tech_fort), with the precious help of Dave Easterday. 
 
@@ -53,9 +54,7 @@ For browser environments you simply need the lokijs.js file contained in src/
 
 You can use bower to install lokijs with `bower install lokijs`
 
-For node environments you can install through `npm install lokijs`.
-
-
+For node and nativescript environments you can install through `npm install lokijs`.
 
 ## Roadmap
 * exactIndex

--- a/src/loki-nativescript-adapter.js
+++ b/src/loki-nativescript-adapter.js
@@ -1,0 +1,60 @@
+ /**
+ * LokiNativescriptAdapter
+ * @author Stefano Falda <stefano.falda@gmail.com>
+ *
+ * Lokijs adapter for nativescript framework (http://www.nativescript.org)
+ *
+ * The db file is created in the app documents folder. 
+ 
+ * How to use:
+ * Just create a new loki db and your ready to go: 
+ * 
+ * let db = new loki('loki.json',{autosave:true});
+ * 
+ */
+
+function LokiNativescriptAdapter() {
+      this.fs = require("file-system");
+  }
+  
+LokiNativescriptAdapter.prototype.loadDatabase = function(dbname, callback){
+    var documents = this.fs.knownFolders.documents();
+    var myFile = documents.getFile(dbname);    
+    //Read from filesystem
+    myFile.readText()
+            .then(function (content) {
+                //The file is empty or missing
+                if (content==""){
+                    callback(new Error("DB file does not exist"));
+                } else {
+                    callback(content);    
+                }
+            }, function (error) {
+                console.log("Error opening db "+dbname+": "+ error);
+                 callback(new Error(error))
+            });
+}
+LokiNativescriptAdapter.prototype.saveDatabase = function(dbname, serialized, callback){
+    var documents = this.fs.knownFolders.documents();
+    var myFile = documents.getFile(dbname);    
+    myFile.writeText(serialized)
+            .then(function () {
+                callback();
+            }, function (error) {
+                console.log("Error saving db "+dbname+": "+ error);
+            });
+    
+}
+
+LokiNativescriptAdapter.prototype.deleteDatabase = function deleteDatabase(dbname, callback) {
+      var documents = this.fs.knownFolders.documents();
+      var file = documents.getFile(dbname);
+      file.remove()
+            .then(function (result) {
+            callback();
+            }, function (error) {
+                callback(error);
+            });
+    };
+    
+module.exports = LokiNativescriptAdapter;

--- a/src/loki-nativescript-adapter.js
+++ b/src/loki-nativescript-adapter.js
@@ -24,16 +24,17 @@ LokiNativescriptAdapter.prototype.loadDatabase = function(dbname, callback){
     myFile.readText()
             .then(function (content) {
                 //The file is empty or missing
-                if (content==""){
+                if (content===""){
                     callback(new Error("DB file does not exist"));
                 } else {
                     callback(content);    
                 }
             }, function (error) {
                 console.log("Error opening db "+dbname+": "+ error);
-                 callback(new Error(error))
+                 callback(new Error(error));
             });
-}
+};
+
 LokiNativescriptAdapter.prototype.saveDatabase = function(dbname, serialized, callback){
     var documents = this.fs.knownFolders.documents();
     var myFile = documents.getFile(dbname);    
@@ -44,7 +45,7 @@ LokiNativescriptAdapter.prototype.saveDatabase = function(dbname, serialized, ca
                 console.log("Error saving db "+dbname+": "+ error);
             });
     
-}
+};
 
 LokiNativescriptAdapter.prototype.deleteDatabase = function deleteDatabase(dbname, callback) {
       var documents = this.fs.knownFolders.documents();

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -622,10 +622,19 @@
       };
 
       var getENV = function () {
+        if (typeof global !== 'undefined' && (global.android || global.NSObject)) {
+          //If no adapter is set use the default nativescript adapter
+          if (!options.adapter) {
+            const LokiNativescriptAdapter = require('./loki-nativescript-adapter');
+            options.adapter=new LokiNativescriptAdapter();
+          }
+          return 'NATIVESCRIPT'; //nativescript
+        }
+        
         if (typeof window === 'undefined') {
           return 'NODEJS';
         }
-
+        
         if (typeof global !== 'undefined' && global.window) {
           return 'NODEJS'; //node-webkit
         }

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -625,7 +625,7 @@
         if (typeof global !== 'undefined' && (global.android || global.NSObject)) {
           //If no adapter is set use the default nativescript adapter
           if (!options.adapter) {
-            let LokiNativescriptAdapter = require('./loki-nativescript-adapter');
+            var LokiNativescriptAdapter = require('./loki-nativescript-adapter');
             options.adapter=new LokiNativescriptAdapter();
           }
           return 'NATIVESCRIPT'; //nativescript

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -625,7 +625,7 @@
         if (typeof global !== 'undefined' && (global.android || global.NSObject)) {
           //If no adapter is set use the default nativescript adapter
           if (!options.adapter) {
-            const LokiNativescriptAdapter = require('./loki-nativescript-adapter');
+            let LokiNativescriptAdapter = require('./loki-nativescript-adapter');
             options.adapter=new LokiNativescriptAdapter();
           }
           return 'NATIVESCRIPT'; //nativescript


### PR DESCRIPTION
I created a new adapter to support loading and saving of the database in a nativescript application.
Because it's possible to detect if the runtime environment is nativescript I've slightly modified the Lokijs file to automatically select the nativescript adapter if no adapter is passed in the options.

Performance seems quite good both in the iOS and in the Android app.
