### PR TITLE
DynamicView: Send notifications and update persistent data even if 'filterInitialized' is false on resultset

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -3083,6 +3083,15 @@
     DynamicView.prototype.evaluateDocument = function (objIndex, isNew) {
       // if no filter applied yet, the result 'set' should remain 'everything'
       if (!this.resultset.filterInitialized) {
+        if (this.options.persistent) {
+          this.resultdata = this.resultset.data();
+        }
+        // need to re-sort to sort new document
+        if (this.sortFunction || this.sortCriteria) {
+          this.queueSortPhase();
+        } else {
+          this.queueRebuildEvent();
+        }
         return;
       }
 
@@ -3178,6 +3187,15 @@
     DynamicView.prototype.removeDocument = function (objIndex) {
       // if no filter applied yet, the result 'set' should remain 'everything'
       if (!this.resultset.filterInitialized) {
+        if (this.options.persistent) {
+          this.resultdata = this.resultset.data();
+        }
+        // in case changes to data altered a sort column
+        if (this.sortFunction || this.sortCriteria) {
+          this.queueSortPhase();
+        } else {
+          this.queueRebuildEvent();
+        }
         return;
       }
 


### PR DESCRIPTION
Unfortunately, the fix for #439 broke things a little bit (causing a regression in a recently released public version 1.4.0): When the `filterInitialized` flag on `resultset` remains `false`, it is still required to send the "rebuild" notifications to the subscribed listeners on the instances of `DynamicView` and update persistent data, if the related option is set on those instances. After fixing that part, we should be fine, I think.

@obeliskos, please, take a quick look when you have time. Based on my internal tests, we should be good after applying the changes that I propose here. (Though the way that I am updating `resultdata` may not be the fastest yet – it may need more fine-tuning; but, at least, it will be correct now.)

BTW, looking at all the duplicate code fragments that either queue the sort phase or just send the 'rebuild' notifications when no sorting is required, I feel more and more like refactoring the `evaluateDocument` and `removeDocument` methods. As soon as I have a little more time in the coming weeks, I will take a closer look at that.

Looking at that code today, I have also realized that when the option for data persistence is enabled on an instance of `DynamicView`, we do not check and respect the cloning option at all: We always push direct references to the collection documents into `resultdata`.