### PR TITLE
Peformance improvements to the current implementation of dotSubScan()

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -227,9 +227,11 @@
      * @param {array} paths - array of properties to drill into
      * @param {function} fun - evaluation function to test with
      * @param {any} value - comparative value to also pass to (compare) fun
+     * @param {number} poffset - index of the item in 'paths' to start the sub-scan from
      */
-    function dotSubScan(root, paths, fun, value) {
-      var path = paths[0];
+    function dotSubScan(root, paths, fun, value, poffset) {
+      var pathOffset = poffset || 0;
+      var path = paths[pathOffset];
       if (typeof root === 'undefined' || root === null || !root.hasOwnProperty(path)) {
         return false;
       }
@@ -237,15 +239,14 @@
       var valueFound = false;
       var element = root[path];
       if (Array.isArray(element)) {
-        var index;
-        for (index in element) {
-          valueFound = valueFound || dotSubScan(element[index], paths.slice(1, paths.length), fun, value);
+        for (var index = 0, len = element.length; index < len; index += 1) {
+          valueFound = valueFound || dotSubScan(element[index], paths, fun, value, pathOffset + 1);
           if (valueFound === true) {
             break;
           }
         }
       } else if (typeof element === 'object') {
-        valueFound = dotSubScan(element, paths.slice(1, paths.length), fun, value);
+        valueFound = dotSubScan(element, paths, fun, value, pathOffset + 1);
       } else {
         valueFound = fun(element, value);
       }


### PR DESCRIPTION
While I liked the recent re-implementation of `dotSubScan` in general. After looking at it, I knew I would have to get back to it sometime and optimize, to keep its performance on a par with our older versions. The main thing about the new code is, that it does excessive "slicing" over the `paths` argument on each and every (recursive) call to `dotSubScan`. And that happens for each document being examined. And for scanning nested arrays that translates into even more work then. Also, iterating over the properties of an array as object, using `for...in`, leads to examining all enumerable properties in the array (for more details, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in).

This submitted fix removes those inconsistencies.