### PR TITLE
Fixing dotSubScan() for null and Date objects (+ a minor logic optimization)

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -240,15 +240,15 @@
       var element = root[path];
       if (Array.isArray(element)) {
         for (var index = 0, len = element.length; index < len; index += 1) {
-          valueFound = valueFound || dotSubScan(element[index], paths, fun, value, pathOffset + 1);
+          valueFound = dotSubScan(element[index], paths, fun, value, pathOffset + 1);
           if (valueFound === true) {
             break;
           }
         }
-      } else if (typeof element === 'object') {
-        valueFound = dotSubScan(element, paths, fun, value, pathOffset + 1);
-      } else {
+      } else if (typeof element !== 'object' || element === null || element instanceof Date) {
         valueFound = fun(element, value);
+      } else {
+        valueFound = dotSubScan(element, paths, fun, value, pathOffset + 1);
       }
 
       return valueFound;


### PR DESCRIPTION
Another part that was missed in the re-worked `dotSubScan()` was that `null` and `Date` objects were not treated properly. Correcting that aspect now.