### PR TITLE
fix for circular structure error when setting ttl - fixes #469

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -906,6 +906,7 @@
       case 'autosaveHandle':
       case 'persistenceAdapter':
       case 'constraints':
+      case 'ttl':
         return null;
       default:
         return value;


### PR DESCRIPTION
When `ttl` is enabled on a new collection, you will get a `TypeError: Converting circular structure to JSON ` error. This PR will fix it.