### PR TITLE
add/remove array of event names

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -514,13 +514,21 @@
 
     /**
      * on(eventName, listener) - adds a listener to the queue of callbacks associated to an event
-     * @param {string} eventName - the name of the event to listen to
+     * @param {string|string[]} eventName - the name(s) of the event(s) to listen to
      * @param {function} listener - callback function of listener to attach
      * @returns {int} the index of the callback in the array of listeners for a particular event
      * @memberof LokiEventEmitter
      */
     LokiEventEmitter.prototype.on = function (eventName, listener) {
-      var event = this.events[eventName];
+      var event;
+
+      if (Array.isArray(eventName)) {
+        eventName.forEach(function(currentEventName) {
+          LokiEventEmitter.prototype.on(currentEventName, listen);
+        });
+      }
+
+      event = this.events[eventName];
       if (!event) {
         event = this.events[eventName] = [];
       }
@@ -556,11 +564,17 @@
 
     /**
      * removeListener() - removes the listener at position 'index' from the event 'eventName'
-     * @param {string} eventName - the name of the event which the listener is attached to
+     * @param {string|string[]} eventName - the name(s) of the event(s) which the listener is attached to
      * @param {function} listener - the listener callback function to remove from emitter
      * @memberof LokiEventEmitter
      */
     LokiEventEmitter.prototype.removeListener = function (eventName, listener) {
+      if (Array.isArray(eventName)) {
+        eventName.forEach(function(currentEventName) {
+          LokiEventEmitter.prototype.removeListener(currentEventName, listen);
+        });
+      }
+
       if (this.events[eventName]) {
         var listeners = this.events[eventName];
         listeners.splice(listeners.indexOf(listener), 1);

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -934,7 +934,7 @@
      * @memberof Loki
      */
     Loki.prototype.serialize = function () {
-      return JSON.stringify(this, this.serializeReplacer, 2); 
+      return JSON.stringify(this, this.serializeReplacer, 2);
     };
     // alias of serialize
     Loki.prototype.toJson = Loki.prototype.serialize;
@@ -3552,7 +3552,7 @@
      */
     Collection.prototype.configureOptions = function (options) {
       options = options || {};
-      
+
       if (options.hasOwnProperty('adaptiveBinaryIndices')) {
         this.adaptiveBinaryIndices = options.adaptiveBinaryIndices;
 
@@ -3928,7 +3928,7 @@
         else {
           this.flagBinaryIndexesDirty();
         }
-        
+
         this.idIndex[position] = newInternal.$loki;
         //this.flagBinaryIndexesDirty();
 
@@ -3995,7 +3995,7 @@
         for (var i = 0; i < dvlen; i++) {
           this.DynamicViews[i].evaluateDocument(addedPos, true);
         }
-        
+
         if (this.adaptiveBinaryIndices) {
           // for each binary index defined in collection, immediately update rather than flag for lazy rebuild
           var bIndices = this.binaryIndices;
@@ -4006,7 +4006,7 @@
         else {
           this.flagBinaryIndexesDirty();
         }
-        
+
         this.commit();
         this.dirty = true; // for autosave scenarios
 
@@ -4093,7 +4093,7 @@
         else {
           this.flagBinaryIndexesDirty();
         }
-        
+
         this.data.splice(position, 1);
         this.removeAutoUpdateObserver(doc);
 
@@ -4165,32 +4165,32 @@
      *    Since multiple documents may contain the same value (which the index is sorted on),
      *    we hone in on range and then linear scan range to find exact index array position.
      * @param {int} dataPosition : coll.data array index/position
-     * @param {string} binaryIndexName : index to search for dataPosition in 
+     * @param {string} binaryIndexName : index to search for dataPosition in
      */
     Collection.prototype.getBinaryIndexPosition = function(dataPosition, binaryIndexName) {
       var val = this.data[dataPosition][binaryIndexName];
       var index = this.binaryIndices[binaryIndexName].values;
-      
+
       // i think calculateRange can probably be moved to collection
       // as it doesn't seem to need resultset.  need to verify
       //var rs = new Resultset(this, null, null);
       var range = this.calculateRange("$eq", binaryIndexName, val);
-      
+
       if (range[0] === 0 && range[1] === -1) {
         // uhoh didn't find range
         return null;
       }
-      
+
       var min = range[0];
       var max = range[1];
-      
+
       // narrow down the sub-segment of index values
-      // where the indexed property value exactly matches our 
+      // where the indexed property value exactly matches our
       // value and then linear scan to find exact -index- position
       for(var idx = min; idx <= max; idx++) {
         if (index[idx] === dataPosition) return idx;
       }
-      
+
       // uhoh
       return null;
     };
@@ -4198,14 +4198,14 @@
     /**
      * Adaptively insert a selected item to the index.
      * @param {int} dataPosition : coll.data array index/position
-     * @param {string} binaryIndexName : index to search for dataPosition in 
+     * @param {string} binaryIndexName : index to search for dataPosition in
      */
     Collection.prototype.adaptiveBinaryIndexInsert = function(dataPosition, binaryIndexName) {
       var index = this.binaryIndices[binaryIndexName].values;
       var val = this.data[dataPosition][binaryIndexName];
       //var rs = new Resultset(this, null, null);
       var idxPos = this.calculateRangeStart(binaryIndexName, val);
-      
+
       // insert new data index into our binary index at the proper sorted location for relevant property calculated by idxPos.
       // doing this after adjusting dataPositions so no clash with previous item at that position.
       this.binaryIndices[binaryIndexName].values.splice(idxPos, 0, dataPosition);
@@ -4214,15 +4214,15 @@
     /**
      * Adaptively update a selected item within an index.
      * @param {int} dataPosition : coll.data array index/position
-     * @param {string} binaryIndexName : index to search for dataPosition in 
+     * @param {string} binaryIndexName : index to search for dataPosition in
      */
     Collection.prototype.adaptiveBinaryIndexUpdate = function(dataPosition, binaryIndexName) {
       // linear scan needed to find old position within index unless we optimize for clone scenarios later
       // within (my) node 5.6.0, the following for() loop with strict compare is -much- faster than indexOf()
-      var idxPos, 
+      var idxPos,
         index = this.binaryIndices[binaryIndexName].values,
         len=index.length;
-      
+
       for(idxPos=0; idxPos < len; idxPos++) {
         if (index[idxPos] === dataPosition) break;
       }
@@ -4233,23 +4233,23 @@
       //this.adaptiveBinaryIndexRemove(dataPosition, binaryIndexName, true);
       this.adaptiveBinaryIndexInsert(dataPosition, binaryIndexName);
     };
-    
+
     /**
      * Adaptively remove a selected item from the index.
      * @param {int} dataPosition : coll.data array index/position
-     * @param {string} binaryIndexName : index to search for dataPosition in 
+     * @param {string} binaryIndexName : index to search for dataPosition in
      */
     Collection.prototype.adaptiveBinaryIndexRemove = function(dataPosition, binaryIndexName, removedFromIndexOnly) {
       var idxPos = this.getBinaryIndexPosition(dataPosition, binaryIndexName);
       var index = this.binaryIndices[binaryIndexName].values;
       var len,
         idx;
-      
+
       if (idxPos === null) {
         // throw new Error('unable to determine binary index position');
         return null;
       }
-      
+
       // remove document from index
       this.binaryIndices[binaryIndexName].values.splice(idxPos, 1);
 
@@ -4258,8 +4258,8 @@
       if (removedFromIndexOnly === true) {
         return;
       }
-      
-      // since index stores data array positions, if we remove a document 
+
+      // since index stores data array positions, if we remove a document
       // we need to adjust array positions -1 for all document positions greater than removed position
       len = index.length;
       for (idx = 0; idx < len; idx++) {
@@ -4271,7 +4271,7 @@
 
     /**
      * Internal method used for index maintenance.  Given a prop (index name), and a value
-     * (which may or may not yet exist) this will find the proper location where it can be added. 
+     * (which may or may not yet exist) this will find the proper location where it can be added.
      */
     Collection.prototype.calculateRangeStart = function (prop, val) {
       var rcd = this.data;
@@ -4299,7 +4299,7 @@
       }
 
       var lbound = min;
-      
+
       if (ltHelper(rcd[index[lbound]][prop], val, false)) {
         return lbound+1;
       }
@@ -4307,7 +4307,7 @@
         return lbound;
       }
     };
-    
+
     /**
      * calculateRange() - Binary Search utility method to find range/segment of values matching criteria.
      *    this is used for collection.find() and first find filter of resultset/dynview

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -520,11 +520,12 @@
      * @memberof LokiEventEmitter
      */
     LokiEventEmitter.prototype.on = function (eventName, listener) {
-      var event;
+      var event,
+          self;
 
       if (Array.isArray(eventName)) {
         eventName.forEach(function(currentEventName) {
-          LokiEventEmitter.prototype.on(currentEventName, listen);
+          self.on(currentEventName, listen);
         });
       }
 
@@ -569,9 +570,10 @@
      * @memberof LokiEventEmitter
      */
     LokiEventEmitter.prototype.removeListener = function (eventName, listener) {
+      var self = this;
       if (Array.isArray(eventName)) {
         eventName.forEach(function(currentEventName) {
-          LokiEventEmitter.prototype.removeListener(currentEventName, listen);
+          self.removeListener(currentEventName, listen);
         });
       }
 


### PR DESCRIPTION
Allow `LokiEventEmitter.prototype.on` and `LokiEventEmitter.prototype.removeListener` to accept arrays of event names to be applied to a given listener.

Also, trim some trailing white space.