### PR TITLE
Add 'addListener' method alias of 'on' method

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -565,6 +565,16 @@
     };
 
     /**
+     * Alias of LokiEventEmitter.prototype.on
+     * addListener(eventName, listener) - adds a listener to the queue of callbacks associated to an event
+     * @param {string|string[]} eventName - the name(s) of the event(s) to listen to
+     * @param {function} listener - callback function of listener to attach
+     * @returns {int} the index of the callback in the array of listeners for a particular event
+     * @memberof LokiEventEmitter
+     */
+    LokiEventEmitter.prototype.addListener = LokiEventEmitter.prototype.on;
+
+    /**
      * removeListener() - removes the listener at position 'index' from the event 'eventName'
      * @param {string|string[]} eventName - the name(s) of the event(s) which the listener is attached to
      * @param {function} listener - the listener callback function to remove from emitter


### PR DESCRIPTION
To make LokiEventEmitter compatible with RxJS 5 event binding addListener and removeListener methods are required.
For more details please check code at  https://github.com/ReactiveX/rxjs/blob/5.0.0-rc.1/src/observable/FromEventObservable.ts#L8-L14

After making it compatible, it is really easy to make any LokiJS event as an observable.
For example:

```TS
coll = db.getCollection('some_collection');
dynamicView =  coll.addDynamicView('some_dynamic_view');

// import Rx.Observable.fromEvent (see RxJs docs)
rebuildEventAsObservable$ =  Rx.Observable.fromEvent(dynamicView, 'rebuild')
  .map(dv => dv.data())
  .subscribe( data => console.log(data));

// can be disposed optionally
rebuildEventAsObservable$.unsubscribe();
```

Benefits: 
The event data can be filtered, buffered, merged with other observables, delayed, throttled or debounced.
Also, when observable is unsubscribed the event listener is removed automatically.