### PR TITLE
#578: Add optional flag for Changes API to limit update operation out…

### DIFF
--- a/spec/generic/changesApi.spec.js
+++ b/spec/generic/changesApi.spec.js
@@ -54,4 +54,43 @@ describe('changesApi', function () {
 
     expect(users.getChanges().length).toEqual(0);
   });
+
+  it('works with delta mode', function () {
+    var db = new loki(),
+    options = {
+      asyncListeners: false,
+      disableChangesApi: false,
+      disableDeltaChangesApi: false
+    },
+    items = db.addCollection('items', options );
+
+    // Add some documents to the collection
+    items.insert({ name : 'mjolnir', owner: 'thor', maker: { name: 'dwarves', count: 1 } });
+    items.insert({ name : 'gungnir', owner: 'odin', maker: { name: 'elves', count: 1 } });
+    items.insert({ name : 'tyrfing', owner: 'Svafrlami', maker: { name: 'dwarves', count: 1 } });
+    items.insert({ name : 'draupnir', owner: 'odin', maker: { name: 'elves', count: 1 } });
+
+    // Find and update an existing document
+    var tyrfing = items.findOne({'name': 'tyrfing'});
+    tyrfing.owner = 'arngrim';
+    items.update(tyrfing);
+    tyrfing.maker.count = 4;
+    items.update(tyrfing);
+
+    var changes = db.serializeChanges(['items']);
+    changes = JSON.parse(changes);
+    
+    expect(changes.length).toEqual(6);
+
+    var firstUpdate = changes[4];
+    expect(firstUpdate.operation).toEqual('U');
+    expect(firstUpdate.obj.owner).toEqual('arngrim');
+    expect(firstUpdate.obj.name).toBeUndefined();
+
+    var secondUpdate = changes[5];
+    expect(secondUpdate.operation).toEqual('U');
+    expect(secondUpdate.obj.owner).toBeUndefined();
+    expect(secondUpdate.obj.maker).toEqual({ count: 4 });
+    
+  });
 });

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -4509,9 +4509,9 @@
       this.getChangeDelta = getChangeDelta;
             
       function getObjectDelta(oldObject, newObject) {
-        var delta = {};
-        var propertyNames = Object.keys(newObject);
+        var propertyNames = newObject !== null && typeof newObject === 'object' ? Object.keys(newObject) : null;
         if (propertyNames && propertyNames.length && ['string', 'boolean', 'number'].indexOf(typeof(newObject)) < 0) {
+          var delta = {};
           for (var i = 0; i < propertyNames.length; i++) {
             var propertyName = propertyNames[i];
             if (newObject.hasOwnProperty(propertyName)) {
@@ -4520,18 +4520,17 @@
               }
               else {
                 var propertyDelta = getObjectDelta(oldObject[propertyName], newObject[propertyName]);
-                if (typeof propertyDelta !== "undefined") {
+                if (typeof propertyDelta !== "undefined" && propertyDelta != {}) {
                   delta[propertyName] = propertyDelta;
                 }
               }
             }
           }
+          return Object.keys(delta).length === 0 ? undefined : delta;
         }
         else {
-          delta = oldObject === newObject ? undefined : newObject;
+          return oldObject === newObject ? undefined : newObject;
         }
-
-        return delta;
       }
 
       this.getObjectDelta = getObjectDelta;
@@ -5206,7 +5205,7 @@
         position = arr[1]; // position in data array
 
         // if configured to clone, do so now... otherwise just use same obj reference
-        newInternal = this.cloneObjects ? clone(doc, this.cloneMethod) : doc;
+        newInternal = this.cloneObjects || !this.disableDeltaChangesApi ? clone(doc, this.cloneMethod) : doc;
 
         this.emit('pre-update', doc);
 

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -1538,7 +1538,7 @@
       for (i; i < len; i += 1) {
         coll = dbObject.collections[i];
 
-        copyColl = this.addCollection(coll.name, { disableChangesApi: coll.disableChangesApi });
+        copyColl = this.addCollection(coll.name, { disableChangesApi: coll.disableChangesApi, disableDeltaChangesApi: coll.disableDeltaChangesApi });
 
         copyColl.adaptiveBinaryIndices = coll.hasOwnProperty('adaptiveBinaryIndices')?(coll.adaptiveBinaryIndices === true): false;
         copyColl.transactional = coll.transactional;
@@ -4620,6 +4620,7 @@
 
       this.setChangesApi = function (enabled) {
         self.disableChangesApi = !enabled;
+        if (!enabled) { self.disableDeltaChangesApi = false; }
         setHandlers();
       };
       /**


### PR DESCRIPTION
#578: Add optional flag for Changes API to limit update operation output to modified properties only.  Also includes properties flagged as unique, since they would be needed to identify the item that is updated.