### PR TITLE
Fixes autosave race condition when using asynchronous adapter

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -2539,8 +2539,10 @@
         }
         // otherwise just pass the serialized database to adapter
         else {
+          // persistenceAdapter might be asynchronous, so we must clear `dirty` immediately
+          // or autosave won't work if an update occurs between here and the callback
+          self.autosaveClearFlags();
           this.persistenceAdapter.saveDatabase(this.filename, self.serialize(), function saveDatabasecallback(err) {
-            self.autosaveClearFlags();
             cFun(err);
           });
         }


### PR DESCRIPTION
Consider this scenario:

- autosave is enabled (easiest to see issue with low autosave timeout, like 150ms)
- asynchronous adapter (say, IndexedDB adapter) is used

and the following steps:

- a bunch of changes (1) are performed. DB is now dirty
- Loki checks if DB is dirty. It's dirty
- saveDatabase() is called
- adapter save is scheduled (but it's asynchronous)
- a bunch of more changes (2) are performed. DB is still dirty
- adapter save is finished
- dirty flags are reset
- Loki checks if DB is dirty. It's not dirty

… except it actually is. But if you don't perform any more changes and reload the website, changes performed between the beginning and end of saveDatabase() will be lost.

Since saveDatabaseInternal clears dirty flags anyway (regardless of whether the save was successful or not), I just moved the dirty flag check to happen synchronously with the call. The effect in success/fail is the same, except now my issue is fixed.

But this doesn't work for the reference mode export (partitioning adapter does its own dirty checking). So probably a better long-term solution would be to have a second dirty flag for when save is in progress, or instead of a boolean flag, increment a dirty counter.