### PR TITLE
#674 fix for browser project: fs not found

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -2241,7 +2241,11 @@
      * @constructor LokiFsAdapter
      */
     function LokiFsAdapter() {
-      this.fs = require('fs');
+      try {
+        this.fs = require('fs');
+      }catch(e) {
+        this.fs = null;
+      }
     }
 
     /**


### PR DESCRIPTION
fix for angular/cli project with error: Module not found: Error: Can't resolve 'fs' 
It can fix other project with webpack when user can't edit webpack config.