### PR TITLE
Update lokijs.js

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -64,7 +64,7 @@
         // iterate all steps in the transform array
         for (idx = 0; idx < transform.length; idx++) {
           // clone transform so our scan/replace can operate directly on cloned transform
-          clonedStep = clone(transform[idx], "shallow-recurse-objects");
+          clonedStep = clone(transform[idx], "parse-stringify");
           resolvedTransform.push(Utils.resolveTransformObject(clonedStep, params));
         }
 


### PR DESCRIPTION
make transform support $or and $and which top children are Array, current transform use 'shallow-recurse-objects', which not deep clone Array, change to use 'parse-stringify' for it.
Example transform:
    var memberleveltx = [
        {
            type: 'find',
            value: {
                '$or': [
                    {
                        'crowd.anyone': true
                    },
                    {
                        'crowd.specified.grade.value': {$contains: '[%lktxp]grade'}
                    }
                ]
            }
        }
    ];