### PR TITLE
Reference `process` on the global object

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -831,7 +831,7 @@
           return 'NODEJS';
         }
 
-        if (typeof global !== 'undefined' && global.window && process) {
+        if (typeof global !== 'undefined' && global.window && global.process) {
           return 'NODEJS'; //node-webkit
         }
 


### PR DESCRIPTION
Hi, 

When using loki.js in a browser environment I am getting the error `Uncaught ReferenceError: process is not defined` when the browser tries to evaluate the getENV() line since `process` is not a global variable in the browser and [use strict](https://github.com/bmac/LokiJS/blob/721748c86a0392900de081651ad7e87536296a9c/src/lokijs.js#L21) is enabling strict mode at the top of the loki.js file.

