### PR TITLE
Corrected $aeq example in Query Examples

### DIFF
--- a/tutorials/Query Examples.md
+++ b/tutorials/Query Examples.md
@@ -60,7 +60,7 @@ var results = coll.find({'legs': { '$ne' : 8 }});
 **$aeq** - filter for document(s) with property of abstract (loose) equality
 ```javascript
 // will match documents with age of '20' or 20
-var results = coll.find(age: {$aeq: 20});
+var results = coll.find({age: {$aeq: 20}});
 ```
 **$dteq** - filter for document(s) with date property equal to provided date value
 ```javascript


### PR DESCRIPTION
When copying/pasting from the $aeq example, I was greeted with a TypeScript error indicating 'Expected 0-1 arguments, but got 2.' - wrapping as a object makes it conform to the PartialModel shape as is expected by find().