### PR TITLE
Allow undefined check on nested objects & add $exists operator

### DIFF
--- a/jsdoc/tutorial-Query Examples.html
+++ b/jsdoc/tutorial-Query Examples.html
@@ -232,7 +232,15 @@ var results = coll.find({
     },{
       'name' : 'Thor'
     }]
-});</code></pre><h3>Features which support 'find' queries</h3><p>These operators can be used to compose find filter objects which can be used within : </p>
+});</code></pre>
+<p><strong>$exists</strong> - filter for documents which contain (even when the value is null) this field or not<p>
+<pre class="prettyprint source lang-javascript"><code>// fetch documents which do not have this field. Use '$exists': true for documents which have this field (it may be null)
+var results = coll.find({
+  'age': {
+    '$exists': false
+  }
+});</code></pre>
+<h3>Features which support 'find' queries</h3><p>These operators can be used to compose find filter objects which can be used within : </p>
 <ul>
 <li>Collection find()</li>
 <li>Collection findOne()</li>

--- a/spec/generic/ops.spec.js
+++ b/spec/generic/ops.spec.js
@@ -321,4 +321,26 @@ describe("Individual operator tests", function() {
     expect(coll.find({ "c.a": { $eq: undefined } }).length).toEqual(6);
     expect(coll.find({ "c": { $eq: undefined } }).length).toEqual(4);
   });
+
+  it('$exists ops work as expected', function() {
+    var db = new loki('db');
+    var coll = db.addCollection('coll');
+
+    coll.insert({ a: null, b: 5, c: { a: 1 }});
+    coll.insert({ a: "11", b: 5, c: { a: 1 }});
+    coll.insert({ a: 2, b: 5, c: { a: 1 }});
+    coll.insert({ a: "1", b: 5, c: { b: 1 }});
+    coll.insert({ a: "4", b: 5, c: { b: 1 }});
+    coll.insert({ a: 7.2, b: 5});
+    coll.insert({ a: "5", b: 5});
+    coll.insert({ a: 4, b: 5});
+    coll.insert({ a: "18.1", b: 5});
+
+    expect(coll.find({ "c.a": { $exists: true } }).length).toEqual(3);
+    expect(coll.find({ "c.a": { $exists: false } }).length).toEqual(6);
+    expect(coll.find({ "c.a.b": { $exists: true } }).length).toEqual(0);
+    expect(coll.find({ "c.a.b": { $exists: false } }).length).toEqual(9);
+    expect(coll.find({ "c": { $exists: true } }).length).toEqual(5);
+    expect(coll.find({ "c": { $exists: false } }).length).toEqual(4);
+  });
 });

--- a/spec/generic/ops.spec.js
+++ b/spec/generic/ops.spec.js
@@ -302,4 +302,23 @@ describe("Individual operator tests", function() {
     expect(coll.find({ a: { $jlte: 7.2 } }).length).toEqual(7);
     expect(coll.find({ a: { $jbetween: [3.2, 7.8] } }).length).toEqual(4);
   });
+
+  it('query nested documents', function() {
+    var db = new loki('db');
+    var coll = db.addCollection('coll');
+
+    coll.insert({ a: null, b: 5, c: { a: 1 }});
+    coll.insert({ a: "11", b: 5, c: { a: 1 }});
+    coll.insert({ a: 2, b: 5, c: { a: 1 }});
+    coll.insert({ a: "1", b: 5, c: { b: 1 }});
+    coll.insert({ a: "4", b: 5, c: { b: 1 }});
+    coll.insert({ a: 7.2, b: 5});
+    coll.insert({ a: "5", b: 5});
+    coll.insert({ a: 4, b: 5});
+    coll.insert({ a: "18.1", b: 5});
+
+    expect(coll.find({ "c.a": { $eq: 1 } }).length).toEqual(3);
+    expect(coll.find({ "c.a": { $eq: undefined } }).length).toEqual(6);
+    expect(coll.find({ "c": { $eq: undefined } }).length).toEqual(4);
+  });
 });

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -335,14 +335,12 @@
     function dotSubScan(root, paths, fun, value, poffset) {
       var pathOffset = poffset || 0;
       var path = paths[pathOffset];
-      if (root === undefined || root === null || !hasOwnProperty.call(root, path)) {
-        if (pathOffset + 1 < paths.length) {
-          return false;
-        }
-      }
 
       var valueFound = false;
-      var element = root[path];
+      var element;
+      if (typeof root === 'object' && path in root) {
+        element = root[path];
+      }
       if (pathOffset + 1 >= paths.length) {
         // if we have already expanded out the dot notation,
         // then just evaluate the test function and value on the element

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -565,6 +565,14 @@
           }
         }
         return false;
+      },
+
+      $exists: function (a, b) {
+        if (b) {
+          return a !== undefined;
+        } else {
+          return a === undefined;
+        }
       }
     };
 

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -336,7 +336,9 @@
       var pathOffset = poffset || 0;
       var path = paths[pathOffset];
       if (root === undefined || root === null || !hasOwnProperty.call(root, path)) {
-        return false;
+        if (pathOffset + 1 < paths.length) {
+          return false;
+        }
       }
 
       var valueFound = false;


### PR DESCRIPTION
1. commit fixes this behaviour:
* db.find({ 'someprop': undefined }) would find any object where a someprop is not set
* db.find({ 'nested.someprop': undefined }) would not find any object where someprop on 'nested' is not set

2. commit adds a $exists operator as in MongoDB (description copied from MongoDB):
Syntax: { field: { $exists: &lt;boolean&gt; } }
When &lt;boolean&gt; is true, $exists matches the documents that contain the field, including documents where the field value is null. If &lt;boolean&gt; is false, the query returns only the documents that do not contain the field.
