### PR TITLE
Precompile $regex filters recursively

### DIFF
--- a/spec/generic/ops.spec.js
+++ b/spec/generic/ops.spec.js
@@ -302,4 +302,24 @@ describe("Individual operator tests", function() {
     expect(coll.find({ a: { $jlte: 7.2 } }).length).toEqual(7);
     expect(coll.find({ a: { $jbetween: [3.2, 7.8] } }).length).toEqual(4);
   });
+
+  it('$regex ops work as expected', function() {
+    var db = new loki('db');
+    var coll = db.addCollection('coll');
+
+    coll.insert({ name : 'mjolnir', count: 73 });
+    coll.insert({ name : 'gungnir', count: 5 });
+    coll.insert({ name : 'tyrfing', count: 15 });
+    coll.insert({ name : 'draupnir', count: 132 });
+
+    expect(coll.find({ name: { $regex: 'nir' } }).length).toEqual(3);
+    expect(coll.find({ name: { $not: { $regex: 'nir' } } }).length).toEqual(1);
+
+    expect(coll.find({ name: { $regex: 'NIR' } }).length).toEqual(0);
+    expect(coll.find({ name: { $regex: [ 'NIR', 'i' ] } }).length).toEqual(3);
+    expect(coll.find({ name: { $not: { $regex: [ 'NIR', 'i' ] } } }).length).toEqual(1);
+
+    expect(coll.find({ name: { $regex: /NIR/i } }).length).toEqual(3);
+    expect(coll.find({ name: { $not: { $regex: /NIR/i } } }).length).toEqual(1);
+  });
 });

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -3227,10 +3227,11 @@
           value = new RegExp(value);
         }
       }
-
-      if (typeof value === 'object') {
+      else if (typeof value === 'object') {
         for (var key in value) {
-          value[key] = precompileQuery(key, value[key]);
+          if (key === '$regex' || typeof value[key] === 'object') {
+            value[key] = precompileQuery(key, value[key]);
+          }
         }
       }
 
@@ -3348,7 +3349,9 @@
         throw new Error('Do not know what you want to do.');
       }
 
-      value = precompileQuery(operator, value);
+      if (operator === '$regex' || typeof value === 'object') {
+        value = precompileQuery(operator, value);
+      }
 
       // if user is deep querying the object such as find('name.first': 'odin')
       var usingDotNotation = (property.indexOf('.') !== -1);

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -3328,14 +3328,27 @@
         throw new Error('Do not know what you want to do.');
       }
 
-      // for regex ops, precompile
-      if (operator === '$regex') {
-        if (Array.isArray(value)) {
-          value = new RegExp(value[0], value[1]);
-        } else if (!(value instanceof RegExp)) {
-          value = new RegExp(value);
+      // precompile recursively
+      function precompile (operator, value) {
+        // for regex ops, precompile
+        if (operator === '$regex') {
+          if (Array.isArray(value)) {
+            value = new RegExp(value[0], value[1]);
+          } else if (!(value instanceof RegExp)) {
+            value = new RegExp(value);
+          }
         }
+
+        if (typeof value === 'object') {
+          for (var key in value) {
+            value[key] = precompile(key, value[key]);
+          }
+        }
+
+        return value;
       }
+
+      value = precompile(operator, value);
 
       // if user is deep querying the object such as find('name.first': 'odin')
       var usingDotNotation = (property.indexOf('.') !== -1);

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -3217,6 +3217,26 @@
     };
     Resultset.prototype.$or = Resultset.prototype.findOr;
 
+    // precompile recursively
+    function precompileQuery (operator, value) {
+      // for regex ops, precompile
+      if (operator === '$regex') {
+        if (Array.isArray(value)) {
+          value = new RegExp(value[0], value[1]);
+        } else if (!(value instanceof RegExp)) {
+          value = new RegExp(value);
+        }
+      }
+
+      if (typeof value === 'object') {
+        for (var key in value) {
+          value[key] = precompileQuery(key, value[key]);
+        }
+      }
+
+      return value;
+    }
+
     /**
      * findAnd() - oversee the operation of AND'ed query expressions.
      *    AND'ed expression evaluation runs each expression progressively against the full collection,
@@ -3328,27 +3348,7 @@
         throw new Error('Do not know what you want to do.');
       }
 
-      // precompile recursively
-      function precompile (operator, value) {
-        // for regex ops, precompile
-        if (operator === '$regex') {
-          if (Array.isArray(value)) {
-            value = new RegExp(value[0], value[1]);
-          } else if (!(value instanceof RegExp)) {
-            value = new RegExp(value);
-          }
-        }
-
-        if (typeof value === 'object') {
-          for (var key in value) {
-            value[key] = precompile(key, value[key]);
-          }
-        }
-
-        return value;
-      }
-
-      value = precompile(operator, value);
+      value = precompileQuery(operator, value);
 
       // if user is deep querying the object such as find('name.first': 'odin')
       var usingDotNotation = (property.indexOf('.') !== -1);


### PR DESCRIPTION
`find({ "name": { $not: { $regex: '^S' }}})`
would result in a "b.test is not a function" error, because $regex would not
have been compiled.