### PR TITLE
More robust check for testing existence of node process global

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -839,7 +839,7 @@
           return 'NODEJS';
         }
 
-        if (typeof global !== 'undefined' && global.window && process) {
+        if (typeof global !== 'undefined' && global.window && typeof process !== 'undefined') {
           return 'NODEJS'; //node-webkit
         }
 


### PR DESCRIPTION
I'm using a combination of rollup and witchcraft to build Loki into an internal library. For some reason, in the browser, this env check was reaching that `if` statement and failing looking for the `process` global variable. Just a small tweak to make that a little more robust.

Let me know if you'd like for me to rebuild (wasn't sure what the policy was there).