### PR TITLE
Allow indexing on nested fields

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -97,15 +97,15 @@
           return undefined;
         }
         if (!usingDotNotation) {
-          return object[path]
+          return object[path];
         }
 
         if (typeof(path) === "string") {
-          path = path.split(".")
+          path = path.split(".");
         }
 
         if (!Array.isArray(path)) {
-          throw new Error("path must be a string or array. Found " + typeof(path))
+          throw new Error("path must be a string or array. Found " + typeof(path));
         }
 
         var index = 0,

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -71,15 +71,6 @@
         return resolvedTransform;
       },
 
-      // Converts a string path to an array path.
-      // E.g "foo.bar" => ["foo", "bar"]
-      castPath: function (value) {
-        if (Array.isArray(value)) {
-          return value;
-        } 
-        return value.split(".");
-      },
-
       // By default (if usingDotNotation is false), looks up path in
       // object via `object[path]`
       //

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -56,7 +56,7 @@
       // top level utility to resolve an entire (single) transform (array of steps) for parameter substitution
       resolveTransformParams: function (transform, params) {
         var idx,
-            clonedStep,
+          clonedStep,
           resolvedTransform = [];
 
         if (typeof params === 'undefined') return transform;
@@ -71,6 +71,8 @@
         return resolvedTransform;
       },
 
+      // Converts a string path to an array path.
+      // E.g "foo.bar" => ["foo", "bar"]
       castPath: function (value) {
         if (Array.isArray(value)) {
           return value;
@@ -78,6 +80,22 @@
         return value.split(".");
       },
 
+      // Gets the value of (possibly nested) path in object. Path can
+      // either be a string or an array of nested field names. The
+      // function will look up the value of object[path[0]], and then
+      // call result[path[1]] on the result, etc etc.
+      //
+      // path can be an array of field names, or a period delimited
+      // path. The latter will be converted into an array before
+      // processing
+      //
+      // If path isn't navigable, or value is null, then defaultValue
+      // is returned
+      //
+      // examples:
+      // getIn({a: 1}, "a") => 1
+      // getIn({a: {b: 1}}, ["a", "b"]) => 1
+      // getIn({a: {b: 1}}, "a.b") => 1
       getIn: function (object, path, defaultValue) {
         if (object == null) {
           return undefined;
@@ -3042,7 +3060,7 @@
         targetEff = 10,
         dc = this.collection.data.length, 
         frl = this.filteredrows.length,
-          hasBinaryIndex = this.collection.binaryIndices.hasOwnProperty(propname);
+        hasBinaryIndex = this.collection.binaryIndices.hasOwnProperty(propname);
 
       if (typeof (options) === 'undefined' || options === false) {
         options = { desc: false };
@@ -3062,7 +3080,6 @@
         
         // if we have a binary index, we can just use that instead of sorting (again)
         if (this.collection.binaryIndices.hasOwnProperty(propname)) {
-
           // make sure index is up-to-date
           this.collection.ensureIndex(propname);
           // copy index values into filteredrows

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -80,22 +80,27 @@
         return value.split(".");
       },
 
-      // Gets the value of (possibly nested) path in object. Path can
-      // either be a string or an array of nested field names. The
-      // function will look up the value of object[path[0]], and then
-      // call result[path[1]] on the result, etc etc.
+      // By default (if usingDotNotation is false), looks up path in
+      // object via `object[path]`
       //
-      // path can be an array of field names, or a period delimited
-      // path. The latter will be converted into an array before
-      // processing
+      // If `usingDotNotation` is true, then the path is assumed to
+      // represent a nested path. It can be in the form of an array of
+      // field names, or a period delimited string. The function will
+      // look up the value of object[path[0]], and then call
+      // result[path[1]] on the result, etc etc.
       //
-      // If path isn't navigable, or value is null, then defaultValue
-      // is returned
+      // If `usingDotNotation` is true, this function still supports
+      // non nested fields.
+      //
+      // `usingDotNotation` is a performance optimization. The caller
+      // may know that a path is *not* nested. In which case, this
+      // function avoids a costly string.split('.')
       //
       // examples:
       // getIn({a: 1}, "a") => 1
-      // getIn({a: {b: 1}}, ["a", "b"]) => 1
-      // getIn({a: {b: 1}}, "a.b") => 1
+      // getIn({a: 1}, "a", true) => 1
+      // getIn({a: {b: 1}}, ["a", "b"], true) => 1
+      // getIn({a: {b: 1}}, "a.b", true) => 1
       getIn: function (object, path, usingDotNotation) {
         if (object == null) {
           return undefined;


### PR DESCRIPTION
Loki doesn't support indexing on nested fields (period-delimited). This PR adds support for it.

The main change is the addition of the `Utils.getIn` function which performs the deep lookup functionality. Initially, I replaced all `object[path]` lookups with this function, but that resulted in a 2x performance penalty due to the `string.split('.')` that was required for each lookup. So instead, I added a flag `usingDotNotation` that can be set so that the function knows whether it needs to split the path at all.

I've been testing it on https://www.gatsbyjs.org/ as a replacement for the in-memory DB and it's working great so far.