### PR TITLE
fix crashing when JSON is incorrect

### DIFF
--- a/src/loki-fs-structured-adapter.js
+++ b/src/loki-fs-structured-adapter.js
@@ -158,7 +158,11 @@
 
       rl.on('line', function (line) {
         if (line !== "") {
-          obj = JSON.parse(line);
+          try {
+            obj = JSON.parse(line);
+          } catch(e) {
+            callback(e);
+          }
           self.dbref.collections[collectionIndex].data.push(obj);
         }
       });


### PR DESCRIPTION
If whole process crashes while storing loki js to the file, the file might be in an error state and it can't be read in the next run. 

The error can't be caught in the application because the error is thrown from JSON.parse inside the callback