### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/jsdoc/index.html
+++ b/jsdoc/index.html
@@ -45,7 +45,7 @@
     <section>
         <article><h1>LokiJS</h1><p><a href="http://lokijs.org">LokiJS.org web site</a> | 
 <a href="https://github.com/techfort/LokiJS">LokiJS GitHub page</a> | 
-<a href="https://rawgit.com/techfort/LokiJS/master/examples/sandbox/LokiSandbox.htm">Sandbox / Playground</a></p>
+<a href="https://combinatronics.com/techfort/LokiJS/master/examples/sandbox/LokiSandbox.htm">Sandbox / Playground</a></p>
 <h2>Documentation Overview</h2><p>This is an early effort to provide a more accurate and up-to-date version of LokiJS documentation by using jsdoc.  Since modifications arise from various contributors, this should allow distributed effort toward 
 maintaining this documentation.  </p>
 <h2>Getting Started</h2><p>Creating a database :</p>


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.