### PR TITLE
remove: avoid "Cannot convert undefined or null to object" error

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -6131,7 +6131,7 @@
         return;
       }
 
-      if (!hasOwnProperty.call(doc, '$loki')) {
+      if (doc === null || !hasOwnProperty.call(doc, '$loki')) {
         throw new Error('Object is not a document stored in the collection');
       }
 

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -1196,22 +1196,37 @@
      * @memberof Loki
      */
     Loki.prototype.removeCollection = function (collectionName) {
-      var i,
-        len = this.collections.length;
+       var i,
+         len = this.collections.length;
 
-      for (i = 0; i < len; i += 1) {
-        if (this.collections[i].name === collectionName) {
-          var tmpcol = new Collection(collectionName, {});
-          var curcol = this.collections[i];
-          for (var prop in curcol) {
-            if (curcol.hasOwnProperty(prop) && tmpcol.hasOwnProperty(prop)) {
-              curcol[prop] = tmpcol[prop];
-            }
-          }
-          this.collections.splice(i, 1);
-          return;
-        }
-      }
+       for (i = 0; i < len; i += 1) {
+         if (this.collections[i].name === collectionName) {
+
+           // get new collection attribute
+           var tmpcol = new Collection(collectionName, {});
+
+           // get current collection attribute
+           var curcol = this.collections[i];
+
+           // delete current collection attributes
+           for (var prop in curcol) {
+             if (curcol.hasOwnProperty(prop)) {
+               curcol[prop] = null;
+             }
+           }
+
+           // remove new collection attributes if needed
+           for (var prop in tmpcol) {
+             curcol[prop] = null;
+           }
+
+           this.collections.splice(i, 1);
+           tmpcol = null;
+           curcol = null;
+           return true;
+         }
+       }
+       return false;
     };
 
     Loki.prototype.getName = function () {
@@ -3059,9 +3074,9 @@
      * var results = users.chain().simplesort('age').data();
      */
     Resultset.prototype.simplesort = function (propname, options) {
-      var eff, 
+      var eff,
         targetEff = 10,
-        dc = this.collection.data.length, 
+        dc = this.collection.data.length,
         frl = this.filteredrows.length,
         hasBinaryIndex = this.collection.binaryIndices.hasOwnProperty(propname);
 
@@ -3078,9 +3093,9 @@
         if (this.filterInitialized) {
           return this;
         }
-        
+
         // otherwise no filters applied implies all documents, so we need to populate filteredrows first
-        
+
         // if we have a binary index, we can just use that instead of sorting (again)
         if (this.collection.binaryIndices.hasOwnProperty(propname)) {
           // make sure index is up-to-date
@@ -3142,7 +3157,7 @@
       }
 
       // at this point, we will not be able to leverage binary index so we will have to do an array sort
-      
+
       // if we have opted to use simplified javascript comparison function...
       if (options.useJavascriptSorting) {
         return this.sort(function(obj1, obj2) {
@@ -3837,8 +3852,8 @@
      *
      * // join orders with relevant product info via eqJoin
      * var orderSummary = orders.chain().eqJoin(products, "prodId", "productId", mapfun).data();
-     * 
-     * console.log(orderSummary);     
+     *
+     * console.log(orderSummary);
      */
     Resultset.prototype.eqJoin = function (joinData, leftJoinKey, rightJoinKey, mapFun, dataOptions) {
 
@@ -4081,10 +4096,10 @@
      *   }
      * ];
      * coll.addTransform('viewPaging', tx);
-     * 
+     *
      * // add some records
-     * 
-     * var results = dv.branchResultset('viewPaging', { pageStart: 10, pageSize: 10 }).data();     
+     *
+     * var results = dv.branchResultset('viewPaging', { pageStart: 10, pageSize: 10 }).data();
      */
     DynamicView.prototype.branchResultset = function (transform, parameters) {
       var rs = this.resultset.branch();
@@ -4680,7 +4695,7 @@
           this.resultdata = this.resultdata.filter(function(obj, idx) { return !fxo[idx]; });
         }
 
-        // and queue sorts 
+        // and queue sorts
         if (this.sortFunction || this.sortCriteria || this.sortCriteriaSimple) {
           this.queueSortPhase();
         } else {
@@ -5275,10 +5290,10 @@
      * // check all indices on a collection, returns array of invalid index names
      * var result = coll.checkAllIndexes({ repair: true, randomSampling: true, randomSamplingFactor: 0.15 });
      * if (result.length > 0) {
-     *   results.forEach(function(name) { 
-     *     console.log('problem encountered with index : ' + name); 
+     *   results.forEach(function(name) {
+     *     console.log('problem encountered with index : ' + name);
      *   });
-     * }     
+     * }
      */
     Collection.prototype.checkAllIndexes = function (options) {
       var key, bIndices = this.binaryIndices;
@@ -5541,7 +5556,7 @@
      * @memberof Collection
      **/
     Collection.prototype.removeDynamicView = function (name) {
-      this.DynamicViews = 
+      this.DynamicViews =
         this.DynamicViews.filter(function(dv) { return dv.name !== name; });
     };
 
@@ -6072,7 +6087,7 @@
 
         // flag collection as dirty for autosave
         this.dirty = true;
-      } 
+      }
       catch (err) {
         this.rollback();
         if (adaptiveOverride) {
@@ -6081,7 +6096,7 @@
         this.console.error(err.message);
         this.emit('error', err);
         return null;
-      }      
+      }
     };
 
     /**
@@ -6089,12 +6104,12 @@
      * @param {object[]|number[]} batch - array of documents or $loki ids to remove
      */
     Collection.prototype.removeBatch = function(batch) {
-      var len = batch.length, 
-        dlen=this.data.length, 
+      var len = batch.length,
+        dlen=this.data.length,
         idx;
       var xlt = {};
       var posx = [];
-      
+
       // create lookup hashobject to translate $loki id to position
       for (idx=0; idx < dlen; idx++) {
         xlt[this.data[idx].$loki] = idx;
@@ -6331,19 +6346,19 @@
           for(rmidx=0;rmidx<rmlen; rmidx++) {
             rxo[dataPosition[rmidx]] = true;
           }
-    
+
           // remove document from index (with filter function)
           bi.values = bi.values.filter(function(di) { return !rxo[di]; });
-    
+
           // if we passed this optional flag parameter, we are calling from adaptiveBinaryIndexUpdate,
           // in which case data positions stay the same.
           if (removedFromIndexOnly === true) {
             return;
           }
-    
+
           var sortedPositions = dataPosition.slice();
           sortedPositions.sort(function (a, b) { return a-b; });
-    
+
           // to remove holes, we need to 'shift down' the index's data array positions
           // we need to adjust array positions -1 for each index data positions greater than removed positions
           len = bi.values.length;


### PR DESCRIPTION
When trying to remove an unexisting doc by his id, this.get() return null. 

But Null is an object so "Parameter is not an object" error is not trigger, 

Then hasOwnProperty.call throw error "Cannot convert undefined or null to object" rather than throw expected error "Object is not a document stored in the collection"