### PR TITLE
Proxify autoupdate

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -4904,32 +4904,6 @@
         this.ensureIndex(indices[idx]);
       }
 
-      /*function observerCallback(changes) {
-
-        var changedObjects = typeof Set === 'function' ? new Set() : [];
-
-        if (!changedObjects.add)
-          changedObjects.add = function (object) {
-            if (this.indexOf(object) === -1)
-              this.push(object);
-            return this;
-          };
-
-        changes.forEach(function (change) {
-          changedObjects.add(change.object);
-        });
-
-        changedObjects.forEach(function (object) {
-          if (!hasOwnProperty.call(object, '$loki'))
-            return self.removeAutoUpdateObserver(object);
-          try {
-            self.update(object);
-          } catch (err) {}
-        });
-      }
-
-      this.observerCallback = observerCallback;*/
-
       //Compare changed object (which is a forced clone) with existing object and return the delta
       function getChangeDelta(obj, old) {
         if (old) {
@@ -5116,21 +5090,6 @@
 
       return Proxy.revocable(object, handler);
     };
-
-    /*
-    Collection.prototype.addAutoUpdateObserver = function (object) {
-      if (!this.autoupdate || typeof Object.observe !== 'function')
-        return;
-
-      Object.observe(object, this.observerCallback, ['add', 'update', 'delete', 'reconfigure', 'setPrototype']);
-    };
-
-    Collection.prototype.removeAutoUpdateObserver = function (object) {
-      if (!this.autoupdate || typeof Object.observe !== 'function')
-        return;
-
-      Object.unobserve(object, this.observerCallback);
-    };*/
 
     /**
      * Adds a named collection transform to the collection

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -6237,7 +6237,6 @@
         }
 
         this.data.splice(position, 1);
-        this.removeAutoUpdateObserver(doc);
 
         // remove id from idIndex
         this.idIndex.splice(position, 1);
@@ -6247,6 +6246,8 @@
         this.emit('delete', arr[0]);
         delete doc.$loki;
         delete doc.meta;
+        if (doc.__isProxy)
+          doc.revoke();
         return doc;
 
       } catch (err) {


### PR DESCRIPTION
since `Object.observe` has been deprecated, I went ahead and updated the feature to use the Proxy class instead. when `autoupdate` is enabled all documents that are inserted via `Collection.insertOne` or copied via `Loki.loadJSONObject` are proxified with `Collection.autoUpdateProxification`, which will return a document encapsulated by a Proxy or, if `autoupdate` is disabled, the object itself

Fixes issue #455 