### PR TITLE
Fix deleteDatabase callback in LokiIndexedAdapter

### DIFF
--- a/src/loki-indexed-adapter.js
+++ b/src/loki-indexed-adapter.js
@@ -219,7 +219,7 @@
         if (id !== 0) {
           adapter.catalog.deleteAppKey(id, callback);
         } else if (typeof (callback) === 'function') {
-          callback({ success: true });
+          callback(null, { success: true });
         }
       });
     };


### PR DESCRIPTION
By convention, the first param in a callback is `err`, and the second one is `value`. According to loki type defs, it is documented as such also.