### PR TITLE
IncrementalIndexedDBAdapter cleanup & performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+* add IncrementalIndexedDBAdapter
+* make ensureIndex faster
+* LokiEventEmitter.emit faster
+* make batch inserts faster (add option to overrideAdaptiveIndices)
+
 ## 1.5.6
 * added support for indexes on nested properties (#718)
 * more robust environment detection (#717)

--- a/spec/incrementalidb.html
+++ b/spec/incrementalidb.html
@@ -56,7 +56,7 @@ function saveAndCheckDatabaseCopyIntegrity(source) {
       const saveTime = new Date() - beforeSave
       expectToBe(saveError, undefined)
 
-      let copy = new loki('indexed_tests', { adapter: new IncrementalIndexedDBAdapter(), verbose: true });
+      let copy = new loki('incremental_idb_tester', { adapter: new IncrementalIndexedDBAdapter(), verbose: true });
       const beforeLoad = new Date()
       copy.loadDatabase({}, (loadError) => {
         const loadTime = new Date() - beforeLoad
@@ -79,10 +79,10 @@ async function startTests(divElement)
 {
   domElement = divElement;
 
-  indexedDB.deleteDatabase("IncrementalAdapterIDB")
+  indexedDB.deleteDatabase("incremental_idb_tester")
 
   let adapter = new IncrementalIndexedDBAdapter()
-  let db = new loki('indexed_tests', { adapter: adapter });
+  let db = new loki('incremental_idb_tester', { adapter: adapter });
 
   let col1 = db.addCollection('test_collection')
   let col2 = db.addCollection('test_collection2')

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -99,16 +99,16 @@
 
       console.time("makeChunks");
       loki.collections.forEach(function(collection, i) {
-        console.time("get dirty chunk ids");
+        // console.time("get dirty chunk ids");
         var dirtyChunks = new Set();
         collection.dirtyIds.forEach(function(lokiId) {
           var chunkId = (lokiId / that.chunkSize) | 0;
           dirtyChunks.add(chunkId);
         });
         collection.dirtyIds = [];
-        console.timeEnd("get dirty chunk ids");
+        // console.timeEnd("get dirty chunk ids");
 
-        console.time("get chunks&serialize");
+        // console.time("get chunks&serialize");
         dirtyChunks.forEach(function(chunkId) {
           var chunkData = that._getChunk(collection, chunkId);
           // we must stringify, because IDB is asynchronous, and underlying objects are mutable
@@ -117,7 +117,7 @@
             value: JSON.stringify(chunkData),
           });
         });
-        console.timeEnd("get chunks&serialize");
+        // console.timeEnd("get chunks&serialize");
 
         collection.data = [];
         // this is recreated on load anyway, so we can make metadata smaller

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -329,14 +329,15 @@
       var openRequest = indexedDB.open(dbname, 1);
 
       openRequest.onupgradeneeded = function(e) {
-        console.log("onupgradeneeded");
         var db = e.target.result;
-        if (db.objectStoreNames.contains('LokiIncrementalData')) {
-          throw new Error("todo");
-          // TODO: Finish this
-        }
 
-        var store = db.createObjectStore('LokiIncrementalData', { keyPath: "key" });
+        if (e.oldVersion < 1) {
+          // Version 1 - Initial - Create database
+          db.createObjectStore('LokiIncrementalData', { keyPath: "key" });
+        } else {
+          // Unknown version
+          throw new Error("Invalid old version " + e.oldVersion + " for IndexedDB upgrade");
+        }
       };
 
       openRequest.onsuccess = function(e) {

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -163,10 +163,6 @@
       var serializedMetadata = JSON.stringify(loki);
       loki = null; // allow GC of the DB copy
 
-      // console.log(chunksToSave)
-      // console.log(chunkIdsToRemove)
-      // console.log(JSON.parse(serializedMetadata))
-
       chunksToSave.push({ key: "loki", value: serializedMetadata });
 
       that._saveChunks(dbname, chunksToSave, callback);
@@ -212,7 +208,6 @@
         var loki;
         var chunkCollections = {};
 
-        // console.time('repack')
         chunks.forEach(function(object) {
           var key = object.key;
           var value = object.value;
@@ -247,8 +242,6 @@
           callback(new Error("Invalid database - unknown chunk found"));
         });
         chunks = null;
-        // console.timeEnd('repack')
-        // console.log('chunkCollections', chunkCollections)
 
         if (!loki) {
           callback(new Error("Invalid database - missing database metadata"));
@@ -271,7 +264,6 @@
     IncrementalIndexedDBAdapter.prototype._sortChunksInPlace = function(chunks) {
       // sort chunks in place to load data in the right order (ascending loki ids)
       // on both Safari and Chrome, we'll get chunks in order like this: 0, 1, 10, 100...
-      // console.time('sort')
       var getSortKey = function(object) {
         var key = object.key;
         if (key.includes(".")) {
@@ -290,8 +282,6 @@
         if (aKey > bKey) return 1;
         return 0;
       });
-      // console.timeEnd('sort')
-      // console.log('Sorted chunks', chunks)
     };
 
     IncrementalIndexedDBAdapter.prototype._populate = function(loki, chunkCollections) {

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -169,7 +169,7 @@
 
       chunksToSave.push({ key: "loki", value: serializedMetadata });
 
-      that._saveChunks(chunksToSave, callback);
+      that._saveChunks(dbname, chunksToSave, callback);
     };
 
     /**
@@ -191,7 +191,7 @@
       var that = this;
       console.log("-- loadDatabase - begin");
       console.time("loadDatabase");
-      this._getAllChunks(function(chunks) {
+      this._getAllChunks(dbname, function(chunks) {
         if (!Array.isArray(chunks)) {
           // we got an error
           callback(chunks);

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -508,10 +508,9 @@
       };
 
       request.onblocked = function(e) {
-        // This should NOT occur, unless code other than this adapter accesses the database
-        that.operationInProgress = false;
+        // We can't call callback with failure status, because this will be called even if we
+        // succeed in just a moment
         console.error("Deleting database failed because it's blocked by another connection", e);
-        callback({ success: false });
       };
 
       console.log("deleteDatabase - exit fn");

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -126,7 +126,7 @@
      */
     IncrementalIndexedDBAdapter.prototype.saveDatabase = function(dbname, loki, callback) {
       var that = this;
-      console.log("-- exportDatabase - begin");
+      console.log("exportDatabase - begin");
       console.time("exportDatabase");
 
       var chunksToSave = [];
@@ -188,7 +188,7 @@
      */
     IncrementalIndexedDBAdapter.prototype.loadDatabase = function(dbname, callback) {
       var that = this;
-      console.log("-- loadDatabase - begin");
+      console.log("loadDatabase - begin");
       console.time("loadDatabase");
       this._getAllChunks(dbname, function(chunks) {
         if (!Array.isArray(chunks)) {
@@ -254,10 +254,8 @@
         loki = JSON.parse(loki);
 
         // populate collections with data
-        console.time("populate");
         that._populate(loki, chunkCollections);
         chunkCollections = null;
-        console.timeEnd("populate");
 
         console.timeEnd("loadDatabase");
         callback(loki);
@@ -402,13 +400,11 @@
 
       tx.onerror = function(e) {
         that.operationInProgress = false;
-        console.error("Error while saving data to database", e);
         callback(e);
       };
 
       tx.onabort = function(e) {
         that.operationInProgress = false;
-        console.error("Abort while saving data to database", e);
         callback(e);
       };
 
@@ -434,22 +430,17 @@
 
       this.operationInProgress = true;
 
-      console.log("getting all chunks");
-      console.time("getChunks");
-
       var tx = this.idb.transaction(['LokiIncrementalData'], "readonly");
 
       var request = tx.objectStore('LokiIncrementalData').getAll();
       request.onsuccess = function(e) {
         that.operationInProgress = false;
         var chunks = e.target.result;
-        console.timeEnd("getChunks");
         callback(chunks);
       };
 
       request.onerror = function(e) {
         that.operationInProgress = false;
-        console.error("Error while fetching data from IndexedDB", e);
         callback(e);
       };
     };
@@ -476,7 +467,7 @@
       this.operationInProgress = true;
 
       var that = this;
-      console.log("deleteDatabase");
+      console.log("deleteDatabase - begin");
       console.time("deleteDatabase");
 
       if (this.idb) {
@@ -489,7 +480,6 @@
       request.onsuccess = function() {
         that.operationInProgress = false;
         console.timeEnd("deleteDatabase");
-        console.log("deleteDatabase done");
         callback({ success: true });
       };
 
@@ -504,8 +494,6 @@
         // succeed in just a moment
         console.error("Deleting database failed because it's blocked by another connection", e);
       };
-
-      console.log("deleteDatabase - exit fn");
     };
 
     return IncrementalIndexedDBAdapter;

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -131,7 +131,6 @@
 
       var chunksToSave = [];
 
-      console.time("makeChunks");
       loki.collections.forEach(function(collection, i) {
         // Find dirty chunk ids
         var dirtyChunks = new Set();
@@ -163,7 +162,6 @@
         });
         loki.collections[i] = { name: collection.name };
       });
-      console.timeEnd("makeChunks");
 
       var serializedMetadata = JSON.stringify(loki);
       loki = null; // allow GC of the DB copy
@@ -395,12 +393,9 @@
 
       this.operationInProgress = true;
 
-      console.time("save chunks to idb");
-
       var tx = this.idb.transaction(['LokiIncrementalData'], "readwrite");
       tx.oncomplete = function() {
         that.operationInProgress = false;
-        console.timeEnd("save chunks to idb");
         console.timeEnd("exportDatabase");
         callback();
       };
@@ -419,12 +414,9 @@
 
       var store = tx.objectStore('LokiIncrementalData');
 
-      console.time("put");
-      // console.log(chunks)
       chunks.forEach(function(object) {
         store.put(object);
       });
-      console.timeEnd("put");
     };
 
     IncrementalIndexedDBAdapter.prototype._getAllChunks = function(dbname, callback) {

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -341,21 +341,21 @@
         if (!that.idb.objectStoreNames.contains('LokiIncrementalData')) {
           onError(new Error("Missing LokiIncrementalData"));
           // Attempt to recover (after reload) by deleting database, since it's damaged anyway
-          that.deleteDatabase(dbname)
+          that.deleteDatabase(dbname);
           return;
         }
 
         console.log("init success");
 
         that.idb.onversionchange = function(versionChangeEvent) {
-          console.log(`IDB version change`, versionChangeEvent)
+          console.log('IDB version change', versionChangeEvent);
           // This function will be called if another connection changed DB version
           // (Most likely database was deleted from another browser tab, unless there's a new version
           // of this adapter, or someone makes a connection to IDB outside of this adapter)
           // We must close the database to avoid blocking concurrent deletes.
           // The database will be unusable after this. Be sure to supply `onversionchange` option
           // to force logout
-          that.idb.close()
+          that.idb.close();
           if (that.options.onversionchange) {
             that.options.onversionchange(versionChangeEvent);
           }

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -780,18 +780,20 @@
      */
     LokiEventEmitter.prototype.emit = function (eventName) {
       var self = this;
-      var selfArgs = Array.prototype.slice.call(arguments, 1);
+      var selfArgs;
       if (eventName && this.events[eventName]) {
-        this.events[eventName].forEach(function (listener) {
-          if (self.asyncListeners) {
-            setTimeout(function () {
+        if (this.events[eventName].length) {
+          selfArgs = Array.prototype.slice.call(arguments, 1);
+          this.events[eventName].forEach(function (listener) {
+            if (self.asyncListeners) {
+              setTimeout(function () {
+                listener.apply(self, selfArgs);
+              }, 1);
+            } else {
               listener.apply(self, selfArgs);
-            }, 1);
-          } else {
-            listener.apply(self, selfArgs);
-          }
-
-        });
+            }
+          });
+        }
       } else {
         throw new Error('No event ' + eventName + ' defined');
       }

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -5309,12 +5309,12 @@
 
       var wrappedComparer =
         (function (prop, data) {
-          var val1, val2, arr;
+          var val1, val2;
+          var propPath = ~prop.indexOf('.') ? prop.split('.') : false;
           return function (a, b) {
-            if (~prop.indexOf('.')) {
-              arr = prop.split('.');
-              val1 = Utils.getIn(data[a], arr, true);
-              val2 = Utils.getIn(data[b], arr, true);
+            if (propPath) {
+              val1 = Utils.getIn(data[a], propPath, true);
+              val2 = Utils.getIn(data[b], propPath, true);
             } else {
               val1 = data[a][prop];
               val2 = data[b][prop];

--- a/tutorials/Persistence Adapters.md
+++ b/tutorials/Persistence Adapters.md
@@ -143,11 +143,36 @@ var idbAdapter = new LokiIndexedAdapter();
 // use paging only if you expect a single collection to be over 50 megs or so
 var pa = new loki.LokiPartitioningAdapter(idbAdapter, { paging: true });
 
-var db = new loki('test.db', { 
+var db = new loki('test.db', {
   adapter: pa,
   autoload: true,
   autoloadCallback : databaseInitialize,
-  autosave: true, 
+  autosave: true,
+  autosaveInterval: 4000
+});
+```
+
+### Example using IncrementalIndexedDBAdapter
+
+A newer, more advanced alternative to `LokiIndexedAdapter` with `LokiPartitioningAdapter` is to use `IncrementalIndexedDBAdapter`.
+Unlike `LokiIndexedAdapter`, the database is saved not as one big JSON blob (or even pages of individual collections), but split into
+small chunks with individual collection documents. When saving, only the chunks with changed
+documents (and database metadata) is saved to IndexedDB. This speeds up small incremental
+saves by an order of magnitude on large (tens of thousands of records) databases. It also
+avoids Safari 13 bug that would cause the database to balloon in size to gigabytes.
+
+`IncrementalIndexedDBAdapter` is not backwards compatible with `LokiIndexedAdapter`.
+
+```html
+<script src="../../src/lokijs.js"></script>
+<script src="../../src/incremental-indexeddb-adapter.js"></script>
+```
+```javascript
+var db = new loki('TestDatabase', {
+  adapter: new IncrementalIndexedDBAdapter(),
+  autoload: true,
+  autoloadCallback : databaseInitialize,
+  autosave: true,
   autosaveInterval: 4000
 });
 ```


### PR DESCRIPTION
This cleans up the mess I left in Incremental IDB in the first PR

- actually use passed db name
- handle errors better
- fix race condition when deleting database
- clean up console logs and such
- add basic docs

additionally:

- a number of performance improvements:
- faster LokiEventEmitter.emit (arguments slicing is expensive)
- faster ensureIndex (indexOf is expensive - 45ms win on a 65K insert sample)
- faster batch inserts (allow to optionally overrideAdaptiveIndices in batch insert, similar to batch updates - optional because it's terrible for small updates to big collections, but this saved almost 2000ms on a 65K insert sample)