### PR TITLE
Make id field configurable per collection

### DIFF
--- a/spec/generic/collection.spec.js
+++ b/spec/generic/collection.spec.js
@@ -306,7 +306,7 @@ describe('collection', function () {
 
   it('allows to specify a custom ID field name and return instances correctly', function() {
     var db = new loki('test_id.db');
-    var coll = db.addCollection('testcoll', { clone:true, idField: '_id' } );
+    var coll = db.addCollection('testcoll', { clone: true, idField: '_id' } );
 
     // listen for insert events to validate objects
     coll.on("insert", function(obj) {

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -88,12 +88,14 @@
 
       // TODO: remove sanity checks when everything is fully tested
       var firstElement = collection.data[firstDataPosition];
-      if (!(firstElement && firstElement.$loki >= minId && firstElement.$loki <= maxId)) {
+      var firstId = firstElement[collection.idField];
+      if (!(firstElement && firstId >= minId && firstId <= maxId)) {
         throw new Error("broken invariant firstelement");
       }
 
       var lastElement = collection.data[lastDataPosition];
-      if (!(lastElement && lastElement.$loki >= minId && lastElement.$loki <= maxId)) {
+      var lastId = lastElement[collection.idField];
+      if (!(lastElement && lastId >= minId && lastId <= maxId)) {
         throw new Error("broken invariant lastElement");
       }
 

--- a/src/loki-incremental-adapter.js
+++ b/src/loki-incremental-adapter.js
@@ -21,8 +21,9 @@
     };
 
     const saveRecord = (coll, obj, dir) => {
-      console.log(`File is ${dir}/${coll}/${obj.$loki}.json`);
-      fs.writeFile(`${dir}/${coll}/${obj.$loki}.json`, JSON.stringify(obj), {
+      const _id = obj[ coll.idField ];
+      console.log(`File is ${dir}/${coll}/${_id}.json`);
+      fs.writeFile(`${dir}/${coll}/${_id}.json`, JSON.stringify(obj), {
         encoding: 'utf8'
       }, (err) => {
         if (err) {

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -6231,13 +6231,13 @@
         return;
       }
 
-      if (!hasOwnProperty.call(doc, '$loki')) {
+      if (!hasOwnProperty.call(doc, this.idField)) {
         throw new Error('Object is not a document stored in the collection');
       }
 
       try {
         this.startTransaction();
-        var arr = this.get(doc.$loki, true),
+        var arr = this.get(doc[this.idField], true),
           // obj = arr[0],
           position = arr[1];
         var self = this;
@@ -6270,13 +6270,13 @@
         this.idIndex.splice(position, 1);
 
         if (this.isIncremental) {
-          this.dirtyIds.push(doc.$loki);
+          this.dirtyIds.push(doc[this.idField]);
         }
 
         this.commit();
         this.dirty = true; // for autosave scenarios
         this.emit('delete', arr[0]);
-        delete doc.$loki;
+        delete doc[this.idField];
         delete doc.meta;
         return doc;
 

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -3727,7 +3727,7 @@
             for (i = 0; i < len; i++) {
               obj = clone(data[i], method);
               if (options.removeMeta) {
-                delete obj.$loki;
+                delete obj[this.collection.idField];
                 delete obj.meta;
               }
               result.push(obj);
@@ -3752,7 +3752,7 @@
         for (i = 0; i < len; i++) {
           obj = clone(data[fr[i]], method);
           if (options.removeMeta) {
-            delete obj.$loki;
+            delete obj[this.collection.idField];
             delete obj.meta;
           }
           result.push(obj);

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -6153,8 +6153,9 @@
 
         // remove from data[] :
         // filter collection data for items not in inclusion hashobject
+        var _idField = this.idField;
         this.data = this.data.filter(function(obj) {
-          return !xo[obj.$loki];
+          return !xo[obj[_idField]];
         });
 
         // remove from idIndex[] :
@@ -6198,7 +6199,7 @@
 
       // create lookup hashobject to translate $loki id to position
       for (idx=0; idx < dlen; idx++) {
-        xlt[this.data[idx].$loki] = idx;
+        xlt[this.data[idx][this.idField]] = idx;
       }
 
       // iterate the batch
@@ -7030,7 +7031,7 @@
      */
     Collection.prototype.stage = function (stageName, obj) {
       var copy = JSON.parse(JSON.stringify(obj));
-      this.getStage(stageName)[obj.$loki] = copy;
+      this.getStage(stageName)[obj[this.idField]] = copy;
       return copy;
     };
 
@@ -7107,11 +7108,11 @@
         if (max !== undefined) {
           if (max < deepProperty(this.data[i], field, deep)) {
             max = deepProperty(this.data[i], field, deep);
-            result.index = this.data[i].$loki;
+            result.index = this.data[i][this.idField];
           }
         } else {
           max = deepProperty(this.data[i], field, deep);
-          result.index = this.data[i].$loki;
+          result.index = this.data[i][this.idField];
         }
       }
       result.value = max;
@@ -7135,11 +7136,11 @@
         if (min !== undefined) {
           if (min > deepProperty(this.data[i], field, deep)) {
             min = deepProperty(this.data[i], field, deep);
-            result.index = this.data[i].$loki;
+            result.index = this.data[i][this.idField];
           }
         } else {
           min = deepProperty(this.data[i], field, deep);
-          result.index = this.data[i].$loki;
+          result.index = this.data[i][this.idField];
         }
       }
       result.value = min;
@@ -7373,7 +7374,7 @@
      */
     UniqueIndex.prototype.update = function (obj, doc) {
       if (this.lokiMap[obj[this.idField]] !== doc[this.field]) {
-        var old = this.lokiMap[obj.$loki];
+        var old = this.lokiMap[obj[this.idField]];
         this.set(doc);
         // make the old key fail bool test, while avoiding the use of delete (mem-leak prone)
         this.keyMap[old] = undefined;

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -4965,7 +4965,7 @@
         });
 
         changedObjects.forEach(function (object) {
-          if (!hasOwnProperty.call(object, '$loki'))
+          if (!hasOwnProperty.call(object, idField))
             return self.removeAutoUpdateObserver(object);
           try {
             self.update(object);
@@ -4994,7 +4994,7 @@
           for (var i = 0; i < propertyNames.length; i++) {
             var propertyName = propertyNames[i];
             if (newObject.hasOwnProperty(propertyName)) {
-              if (!oldObject.hasOwnProperty(propertyName) || self.uniqueNames.indexOf(propertyName) >= 0 || propertyName == '$loki' || propertyName == 'meta') {
+              if (!oldObject.hasOwnProperty(propertyName) || self.uniqueNames.indexOf(propertyName) >= 0 || propertyName == idField || propertyName == 'meta') {
                 delta[propertyName] = newObject[propertyName];
               }
               else {
@@ -5572,7 +5572,7 @@
 
       this.idIndex = [];
       for (i; i < len; i += 1) {
-        this.idIndex.push(this.data[i].$loki);
+        this.idIndex.push(this.data[i][this.idField]);
       }
     };
 

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -4791,6 +4791,7 @@
      * @constructor Collection
      * @implements LokiEventEmitter
      * @param {string} name - collection name
+     * @param {string} [options.idField='$loki'] - optional name to use for ID field, default '$loki'
      * @param {(array|object)=} options - (optional) array of property names to be indicized OR a configuration object
      * @param {array=} [options.unique=[]] - array of property names to define unique constraints for
      * @param {array=} [options.exact=[]] - array of property names to define exact constraints for


### PR DESCRIPTION
The default '$loki' attribute for object ids may work in some cases, but at times it is necessary to specify a different field name to use, for example to achieve compatibility with existing data models or other backends like MongoDB.
This PR makes the name of the ID field configurable per collection, still defaulting to '$loki' but enabling the use of custom field names like '_id'.
npm test passes, one additional test case added. 