### PR TITLE
Update homepage URL

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,6 +1,6 @@
 # LokiJS
 
-[LokiJS.org web site](http://lokijs.org) | 
+[LokiJS.org web site](http://techfort.github.io/LokiJS/) | 
 [LokiJS GitHub page](https://github.com/techfort/LokiJS) | 
 [Sandbox / Playground](https://rawgit.com/techfort/LokiJS/master/examples/sandbox/LokiSandbox.htm)
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "lokijs",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Fast document oriented javascript in-memory database",
-  "homepage": "http://lokijs.org",
+  "homepage": "http://techfort.github.io/LokiJS/",
   "main": "src/lokijs.js",
   "directories": {
     "example": "examples"


### PR DESCRIPTION
Update lokijs homepage URL in package.json and JSDoc to point to http://techfort.github.io/LokiJS/. This should stop sending traffic from npm to lokijs.org.

Please let me know if there is a better target URL (the wiki perhaps?). Also, we'd need to update the wiki to point to the new URL as well (currently https://github.com/techfort/LokiJS/wiki also has a link to lokijs.org).

For issue #804 .
