### PR TITLE
capture async errors

### DIFF
--- a/src/loki-indexed-adapter.js
+++ b/src/loki-indexed-adapter.js
@@ -116,6 +116,10 @@
       // lookup up db string in AKV db
       this.catalog.getAppKey(appName, dbname, function(result) {
         if (typeof (callback) === 'function') {
+          if (result instanceof Error) {
+            callback(result);
+            return;
+          }
           if (result.id === 0) {
             callback(null);
             return;
@@ -417,7 +421,11 @@
           }
 
           if (typeof(usercallback) === 'function') {
-            usercallback(lres);
+            try {
+              usercallback(lres);
+            } catch(err) {
+              usercallback(err);
+            }
           }
           else {
             console.log(lres);

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -2090,7 +2090,8 @@
           pageIndex: 0
         };
 
-        self.loadNextPartition(0, function() {
+        self.loadNextPartition(0, function(err) {
+          if (err) return callback(err);
           callback(self.dbref);
         });
       });
@@ -2137,6 +2138,7 @@
 
       // load whatever page is next in sequence
       this.adapter.loadDatabase(keyname, function(result) {
+        if (result instanceof Error) return callback(result);
         var data = result.split(self.options.delimiter);
         result = ""; // free up memory now that we have split it into array
         var dlen = data.length;


### PR DESCRIPTION
Currently, any error inside the success handler for the indexeddb key lookup results in the database not loading, but the loadDatabase method (or autoload callback) returning successfully (so that the consuming method thinks everything is ok).
With these changes, I just tried to pass the error up through the callbacks, so I will know something is wrong when loadDatabase fails.