### PR TITLE
Column comparisons & Fix unique index bug

### DIFF
--- a/spec/generic/ops.spec.js
+++ b/spec/generic/ops.spec.js
@@ -428,4 +428,23 @@ describe("Individual operator tests", function() {
       }
     }).length).toBe(1)
   });
+
+  it('$$op column comparisons work', function () {
+    var db = new loki('db');
+    var coll = db.addCollection('coll');
+
+    coll.insert({ a: null, b: 5 });
+    coll.insert({ a: '5', b: 5 });
+    coll.insert({ a: 5, b: 5 });
+    coll.insert({ a: 6, b: 5 });
+    coll.insert({ a: 3, b: 5 });
+    coll.insert({ a: 3, b: 'number' });
+
+    expect(coll.find({ a: { $$eq: 'b' } }).length).toEqual(1);
+    expect(coll.find({ a: { $$aeq: 'b' } }).length).toEqual(2);
+    expect(coll.find({ a: { $$ne: 'b' } }).length).toEqual(5);
+    expect(coll.find({ a: { $$gt: 'b' } }).length).toEqual(1);
+    expect(coll.find({ a: { $$gte: 'b' } }).length).toEqual(2);
+    expect(coll.find({ a: { $$type: 'b' } }).length).toEqual(1);
+  });
 });

--- a/spec/generic/ops.spec.js
+++ b/spec/generic/ops.spec.js
@@ -440,11 +440,59 @@ describe("Individual operator tests", function() {
     coll.insert({ a: 3, b: 5 });
     coll.insert({ a: 3, b: 'number' });
 
+    // standard case
     expect(coll.find({ a: { $$eq: 'b' } }).length).toEqual(1);
     expect(coll.find({ a: { $$aeq: 'b' } }).length).toEqual(2);
     expect(coll.find({ a: { $$ne: 'b' } }).length).toEqual(5);
     expect(coll.find({ a: { $$gt: 'b' } }).length).toEqual(1);
-    expect(coll.find({ a: { $$gte: 'b' } }).length).toEqual(2);
+    expect(coll.find({ a: { $$gte: 'b' } }).length).toEqual(3);
+
+    // function variant
+    expect(coll.find({ a: { $$gt: function (record) { return record.b - 1 } } }).length).toEqual(4);
+
+    // comparison on filtered rows
+    expect(coll.find({ b: { $gt: 0 }, a: { $$aeq: 'b' } }).length).toEqual(2);
+
+    // type
     expect(coll.find({ a: { $$type: 'b' } }).length).toEqual(1);
+    expect(coll.find({ a: { $type: { $$eq: 'b' } } }).length).toEqual(1);
+
+    // $not, $and, $or
+    expect(coll.find({ a: { $not: { $$type: 'b' } } }).length).toEqual(5);
+    expect(coll.find({ a: { $and: [{ $type: 'number' }, { $$gte: 'b' }] } }).length).toEqual(2);
+    expect(coll.find({ a: { $or: [{ $eq: null }, { $$gt: 'b' }] } }).length).toEqual(2);
+
+    // $len
+    coll.insert({ text1: 'blablabla', len: 10 })
+    coll.insert({ text1: 'abcdef', len: 6 })
+    coll.insert({ text1: 'abcdef', len: 3 })
+    expect(coll.find({ text1: { $len: { $$eq: 'len' } } }).length).toEqual(1);
+
+    // $size
+    coll.insert({ array1: [1, 2, 3], size: 2 })
+    coll.insert({ array1: [1, 2], size: 1 })
+    coll.insert({ array1: [1, 2], size: 3 })
+    coll.insert({ array1: [1, 2, 3, 4], size: 5 })
+    expect(coll.find({ array1: { $size: { $$eq: 'size' } } }).length).toEqual(0);
+    expect(coll.find({ array1: { $size: { $$lt: 'size' } } }).length).toEqual(2);
+
+    // $elemMatch
+    coll.insert({ els: [{ a: 1, b: 2 }] })
+    coll.insert({ els: [{ a: 1, b: 2 }, { a: 2, b: 2 }] })
+    expect(coll.find({ els: { $elemMatch: { a: { $$eq: 'b' } } } }).length).toEqual(1);
+
+    // $elemMatch - dot scan
+    coll.insert({ els2: [{ a: { val: 1 }, b: 2 }] })
+    coll.insert({ els2: [{ a: { val: 1 }, b: 2 }, { a: { val: 2 }, b: 2 }] })
+    expect(coll.find({ els2: { $elemMatch: { 'a.val': { $$eq: 'b' } } } }).length).toEqual(1);
+
+    // dot notation
+    coll.insert({ c: { val: 5 }, b: 5 });
+    coll.insert({ c: { val: 6 }, b: 5 });
+    coll.insert({ c: { val: 7 }, b: 6 });
+    expect(coll.find({ 'c.val': { $$gt: 'b' } }).length).toEqual(2);
+
+    // dot notation - on filtered rows
+    expect(coll.find({ b: { $gt: 0 }, 'c.val': { $$gt: 'b' } }).length).toEqual(2);
   });
 });

--- a/spec/generic/unique.spec.js
+++ b/spec/generic/unique.spec.js
@@ -83,7 +83,7 @@ describe('Constraints', function () {
   it('coll.clear should affect unique indices correctly', function() {
     var db = new loki();
     var coll = db.addCollection('users', { unique: ['username'] });
-    
+
     coll.insert({ username: 'joe', name: 'Joe' });
     coll.insert({ username: 'jack', name: 'Jack' });
     coll.insert({ username: 'jake', name: 'Jake' });
@@ -100,7 +100,7 @@ describe('Constraints', function () {
 
     var db = new loki();
     var coll = db.addCollection('users', { unique: ['username'] });
-    
+
     coll.insert({ username: 'joe', name: 'Joe' });
     coll.insert({ username: 'jack', name: 'Jack' });
     coll.insert({ username: 'jake', name: 'Jake' });
@@ -122,18 +122,18 @@ describe('Constraints', function () {
       {name:'Jormungandr', legs: 0},
       {name:'Hel', legs: 2}
     ];
-  
+
     var db = new loki('test.db');
     var collection = db.addCollection("children", {
       unique: ["name"]
     });
-  
+
     data.forEach(function(c) {
       collection.insert(JSON.parse(JSON.stringify(c)));
     });
 
     collection.findAndRemove();
-  
+
     // reinsert 2 of the 3 original docs
     // implicitly 'expecting' that this will not throw exception on Duplicate key for property name(s)
     collection.insert(JSON.parse(JSON.stringify(data[0])));
@@ -158,12 +158,12 @@ describe('Constraints', function () {
       {name:'Jormungandr', legs: 0},
       {name:'Hel', legs: 2}
     ];
-  
+
     var db = new loki('test.db');
     var collection = db.addCollection("children", {
       unique: ["name"]
     });
-  
+
     data.forEach(function(c) {
       collection.insert(JSON.parse(JSON.stringify(c)));
     });
@@ -171,7 +171,7 @@ describe('Constraints', function () {
     collection.chain().update(function(obj) {
       obj.name = obj.name + '2';
     });
-  
+
     // implicitly 'expecting' that this will not throw exception on Duplicate key for property name: Sleipnir
     data.forEach(function(c) {
       collection.insert(JSON.parse(JSON.stringify(c)));
@@ -221,5 +221,14 @@ describe('Constraints', function () {
     expect(keys[3]).toEqual('Jormungandr2');
     expect(keys[4]).toEqual('Sleipnir');
     expect(keys[5]).toEqual('Sleipnir2');
+  });
+  it('should not crash on unsafe strings', function () {
+    var db = new loki();
+    var coll = db.addCollection('local_storage', {
+      unique: ['key']
+    });
+    expect(coll.by('key', 'hasOwnProperty')).toBe(undefined);
+    coll.insert({ key: 'hasOwnProperty', name: 'hey' });
+    expect(coll.by('key', 'hasOwnProperty').name).toBe('hey');
   });
 });

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -682,7 +682,7 @@
 
     // ops that can be used with { $$op: 'column-name' } syntax
     var valueLevelOps = ['$eq', '$aeq', '$ne', '$dteq', '$gt', '$gte', '$lt', '$lte', '$jgt', '$jgte', '$jlt', '$jlte', '$type'];
-    valueLevelOps.forEach(op => {
+    valueLevelOps.forEach(function (op) {
       var fun = LokiOps[name];
       LokiOps['$' + op] = function (a, b, record) {
         return callValueOp(fun, a, record, b);

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -7509,8 +7509,8 @@
 
     function UniqueIndex(uniqueField) {
       this.field = uniqueField;
-      this.keyMap = {};
-      this.lokiMap = {};
+      this.keyMap = Object.create(null);
+      this.lokiMap = Object.create(null);
     }
     UniqueIndex.prototype.keyMap = {};
     UniqueIndex.prototype.lokiMap = {};
@@ -7557,12 +7557,12 @@
       }
     };
     UniqueIndex.prototype.clear = function () {
-      this.keyMap = {};
-      this.lokiMap = {};
+      this.keyMap = Object.create(null);
+      this.lokiMap = Object.create(null);
     };
 
     function ExactIndex(exactField) {
-      this.index = {};
+      this.index = Object.create(null);
       this.field = exactField;
     }
 

--- a/tutorials/Query Examples.md
+++ b/tutorials/Query Examples.md
@@ -319,6 +319,15 @@ var results = coll.find({
 });
 ```
 
+**$$eq, $$eq, etc.** - many filters support column comparisons - comparing one column in a document
+with another (instead of between column and value):
+```javascript
+// fetch documents where foo > bar
+var results = coll.find({{ foo: { $$gt: 'bar' } }})
+
+// instead of passing second column name, you can pass a function that computes value to compare against
+var results = coll.find({{ foo: { $$lt: doc => doc.bar + 1 } }})
+```
 ### Features which support 'find' queries
 These operators can be used to compose find filter objects which can be used within : 
 * Collection find()


### PR DESCRIPTION
Fixes #636.

This introduces a new class of filters, that do comparisons on document level, instead of on property level.

The key use case is allowing column comparisons, e.g. fetch all tasks where task.foo > task.bar. The syntax is this:

```js
// simple column comparison
{ foo: { $$gt: 'bar' } } 

// for more flexibility, function can be passed
{ foo: { $$gt: doc => doc.bar + 1 } }
```

I took care not to affect hot path's performance. So I don't do any `$$` checks — instead, all LokiOps now take a third argument (document) that's passed around - but only $$ops actually use it.

Nested filters - $or, $and, $not, $len, $size, $elemMatch all work.

I'm also thinking of adding object-level $filter `.find({ $filter: (doc) => xxx })` and extending property-level $filter `.find({ foo: { $filter: (foo, doc) => xxx }  })` for object-level comparisons without having to completely resort to using `.where()`. But I didn't do it in this PR.

Additionally, I fix https://github.com/techfort/LokiJS/issues/839 here. Plain objects {} are not safe for use with arbitrary keys. Since Loki doesn't do ES6, I used prototype-less Objects to fix the issue.