### PR TITLE
IncrementalIDB - MegaChunking

### DIFF
--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -492,9 +492,9 @@
     }
 
     function populateLoki(loki, chunkMap, deserializeChunk) {
-      loki.collections.forEach(function(collectionStub, i) {
+      loki.collections.forEach(function populateCollection(collectionStub, i) {
+        DEBUG && console.time('populate collection ' + collectionStub.name);
         var chunkCollection = chunkMap[collectionStub.name];
-
         if (chunkCollection) {
           if (!chunkCollection.metadata) {
             throw new Error("Corrupted database - missing metadata chunk for " + collectionStub.name);
@@ -505,7 +505,7 @@
           loki.collections[i] = collection;
 
           var dataChunks = chunkCollection.dataChunks;
-          dataChunks.forEach(function(chunkObj, i) {
+          dataChunks.forEach(function populateChunk(chunkObj, i) {
             var chunk = JSON.parse(chunkObj);
             chunkObj = null; // make string available for GC
             dataChunks[i] = null;
@@ -519,6 +519,7 @@
             });
           });
         }
+        DEBUG && console.timeEnd('populate collection ' + collectionStub.name);
       });
     }
 

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -561,6 +561,11 @@
         DEBUG && console.log("init success");
 
         db.onversionchange = function(versionChangeEvent) {
+          // Ignore if database was deleted and recreated in the meantime
+          if (that.idb !== db) {
+            return;
+          }
+
           DEBUG && console.log('IDB version change', versionChangeEvent);
           // This function will be called if another connection changed DB version
           // (Most likely database was deleted from another browser tab, unless there's a new version
@@ -568,7 +573,8 @@
           // We must close the database to avoid blocking concurrent deletes.
           // The database will be unusable after this. Be sure to supply `onversionchange` option
           // to force logout
-          db.close();
+          that.idb.close();
+          that.idb = null;
           if (that.options.onversionchange) {
             that.options.onversionchange(versionChangeEvent);
           }

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -493,7 +493,6 @@
 
     function populateLoki(loki, chunkMap, deserializeChunk) {
       loki.collections.forEach(function populateCollection(collectionStub, i) {
-        // DEBUG && console.time('populate collection ' + collectionStub.name);
         var chunkCollection = chunkMap[collectionStub.name];
         if (chunkCollection) {
           if (!chunkCollection.metadata) {
@@ -512,7 +511,6 @@
             dataChunks[i] = null;
           });
         }
-        // DEBUG && console.timeEnd('populate collection ' + collectionStub.name);
       });
     }
 
@@ -659,8 +657,6 @@
 
           doneCount += 1;
           if (doneCount === megachunkCount) {
-            // console.log('!! mega chunk, mega success !!')
-            // console.log('chunk count', allChunks.length);
             callback(allChunks);
           }
         }
@@ -702,57 +698,7 @@
         });
       }
 
-      function getKeysViaCursor() {
-        var allChunksViaCursor = []
-        var cursors = 20;
-        var cursorDoneCount = 0;
-        var deserializeChunk = that.options.deserializeChunk;
-
-        function makeCursorOnSuccess(skip, jump) {
-          var didSkip = false
-          return function(event) {
-            var cursor = event.target.result;
-            if(cursor) {
-              if (!didSkip) {
-                didSkip = true;
-                if (skip > 0) {
-                  cursor.advance(skip);
-                  return;
-                }
-              }
-
-              var chunk = cursor.value
-              chunk.value = JSON.parse(chunk.value)
-              const segments = chunk.key.split('.')
-              if (segments.length === 3 && segments[1] === 'chunk') {
-                if (deserializeChunk) {
-                  chunk.value = deserializeChunk(segments[0], chunk.value);
-                }
-              }
-              allChunksViaCursor.push(chunk);
-
-              cursor.advance(jump);
-            } else {
-              console.log('done', skip, jump)
-              cursorDoneCount += 1;
-              if (cursorDoneCount === cursors) {
-                console.log(allChunksViaCursor)
-                callback(allChunksViaCursor)
-              }
-            }
-          }
-        }
-
-        for (var c=0;c<cursors;c++) {
-          store.openCursor().onsuccess = makeCursorOnSuccess(c, cursors);
-        }
-
-        onFetchStart();
-      }
-
-      // getAllChunks();
-      // getAllKeys();
-      getKeysViaCursor()
+      getAllKeys();
     };
 
     /**


### PR DESCRIPTION
(WIP, please don't review the code yet)

Yes, it's me again, with yet another pull request full of strange, complicated code — and another promise that it's worth it for performance 🙃

I think I'm approaching the limits of what IndexedDB can do performance-wise, but it's important for my use case to squeeze all that's possible out of it ;)

TL;DR: It loads the database 22% faster ;)

I made a picture to explain the problem that this PR is trying to solve:

<img width="1411" alt="Captura de pantalla 2020-12-10 a las 10 14 35" src="https://user-images.githubusercontent.com/183747/101753617-277dd300-3ad3-11eb-9b09-3ca7c1f6d0f7.png">

IndexedDB is implemented (in all browsers as far as I can tell, but certainly in Chrome and Safari) with a multi-process architecture, and the cross-process communication is not very efficient.  This can be seen above - waiting for IDB to fetch data from disk takes relatively little time, and most of the time is spent waiting for the XPC dance to complete transferring data -- and clearly, it's not very well tuned, as the CPU usage in the browser process is very low.

So the goal is to:

- layer enough work at the same time that CPU utilization stays high
- reduce the initial wait for IDB when no work happens on main thread
- take better advantage of the concurrency opportunity, and try to keep both main/browser and IDB processes busy at the same time.

This is what I achieved:

<img width="1407" alt="Captura de pantalla 2020-12-10 a las 9 59 41" src="https://user-images.githubusercontent.com/183747/101754683-4af54d80-3ad4-11eb-917d-a79782a97f63.png">

This achieves 22% improvement on my benchmark, and likely more free performance for apps that didn't opt to manually tune IncrementalIDB by supplying `serializeChunk`/`deserializeChunk`.

Instead of calling `IDBObjectStore.getAll()`, I'm fetching multiple `megachunks` (chunks of chunks 🙃) - currently 20 requests using adjacent IDBKeyRanges. AFAICT, the IDB process in both Safari and Chrome does the first phase (actual disk/db work) sequentially, so there's no win here, but the XPC is more efficient for some reason. I guess since the IDB process sends more messages to browser process, there are fewer gaps in processing them on browser side, so CPU utilization stays higher.

In a further improvement (I call this `megachunk interleaving`), I only request first half of the megachunks initially, and then in in `onsuccess` of each one I request the `(i+n/2)`th chunk. This reduces the initial wait for IDB to almost nothing, and improves concurrency, as the IDB process is kept busy while JS is processing the first half of its work. (I also moved most of the chunk processing - JSON.parse and optional deserializeChunk from the end of the process much earlier - to each megachunk's onSuccess, so that main and IDB processes can be kept busy at the same time… I think this should also improve GC pressure a little bit, but I haven't yet figured out a good technique for measuring that, since it's very noisy)

I'm almost out of ideas for further improvements for now, and the law of diminishing returns is catching up to me, so it'll probably the last PR in the series for a while...

PS. In case you were wondering about using IDBCursor to maximize concurrency opportunity — I tried that multiple times, and it doesn't work. I tried interleaving multiple IDBCursors, and I got to nearly the same performance as interleaved megachunking, but still slower. There are just too many useless pauses on main thread...