### PR TITLE
added missing null check to dot sub scan fixes #891

### DIFF
--- a/spec/generic/ops.spec.js
+++ b/spec/generic/ops.spec.js
@@ -359,6 +359,17 @@ describe("Individual operator tests", function() {
     expect(coll.find({ "c": { $eq: undefined } }).length).toEqual(4);
   });
 
+  it('query nested documents with nullable object', function() {
+    var db = new loki('db');
+    var coll = db.addCollection('coll');
+
+    coll.insert({ a: null, b: 5, c: { a: 1 }});
+    coll.insert({ a: "11", b: 5, c: { a: 1 }});
+    coll.insert({ a: "11", b: 5, c: null});
+
+    expect(coll.find({ "c.a": { $eq: 1 } }).length).toEqual(2);
+  });
+
   it('$exists ops work as expected', function() {
     var db = new loki('db');
     var coll = db.addCollection('coll');

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -415,7 +415,7 @@
 
       var valueFound = false;
       var element;
-      if (typeof root === 'object' && path in root) {
+      if (root !== null && typeof root === 'object' && path in root) {
         element = root[path];
       }
       if (pathOffset + 1 >= paths.length) {


### PR DESCRIPTION
When a filter was deep dot filter is applied on null value, the code throws an exception. This is due to a missing null check. `typeof null` is always `object` which is a questionable part of JavaScript and leads to bugs like this...