### PR TITLE
Fixed typo in 'Query Examples.md'

### DIFF
--- a/tutorials/Query Examples.md
+++ b/tutorials/Query Examples.md
@@ -32,7 +32,7 @@ function sleipnirFilter(obj) {
 }
 
 // and then pass that
-results = coll.where(sleipnirFunction);
+results = coll.where(sleipnirFilter);
 ```
 
 ### 'Find' queries


### PR DESCRIPTION
I fixed a minor typo in the example code for Where queries in the 'Query Example.md' file. The function 'sleipnirFilter' was defined but the undefined function 'sleipnirFunction' was used in the example code.