### PR TITLE
Check for arrays when matching regex

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -559,6 +559,10 @@
       },
 
       $regex: function (a, b) {
+        if(Array.isArray(a))
+        {
+          return a.some(item => b.test(item));
+        }
         return b.test(a);
       },
 


### PR DESCRIPTION
When trying to match a regex on array elements the output was the result of trying to match a regex on the concatenation of the array elements instead of each element separately  